### PR TITLE
Fix #453 map setting issue

### DIFF
--- a/app/assets/javascripts/maps.js.coffee
+++ b/app/assets/javascripts/maps.js.coffee
@@ -37,12 +37,8 @@ $(document).ready ->
       sw = marker_bounds.getSouthWest()
 
       if marker_bounds.isEmpty()
-        $('.north_limit').val(80)
-        $('.east_limit').val(-40)
-        $('.south_limit').val(-80)
-        $('.west_limit').val(-20)
-
         displayNoDataMessage(path)
+
       else
         $('.north_limit').val(ne.lat())
         $('.east_limit').val(ne.lng())
@@ -50,8 +46,8 @@ $(document).ready ->
         $('.west_limit').val(sw.lng())
 
         clearNoDataMessage()
+        $('.map').trigger('update_map')
 
-      $('.map').trigger('update_map')
       false
 
     displayNoDataMessage = (path) ->

--- a/app/assets/javascripts/maps.js.coffee
+++ b/app/assets/javascripts/maps.js.coffee
@@ -42,7 +42,7 @@ $(document).ready ->
         $('.south_limit').val(-80)
         $('.west_limit').val(-20)
 
-        displayNoDataMessage()
+        displayNoDataMessage(path)
       else
         $('.north_limit').val(ne.lat())
         $('.east_limit').val(ne.lng())
@@ -54,8 +54,11 @@ $(document).ready ->
       $('.map').trigger('update_map')
       false
 
-    displayNoDataMessage = ->
-      $('.no-map-match-message').text('No matching map data found')
+    displayNoDataMessage = (path) ->
+      if path == '/countries/'
+        $('.no-map-match-message').text('No matching map data found from country')
+      else
+        $('.no-map-match-message').text('No matching map data found from language')
 
     clearNoDataMessage = ->
       $('.no-map-match-message').text('')

--- a/app/assets/stylesheets/_layout_style.css.scss
+++ b/app/assets/stylesheets/_layout_style.css.scss
@@ -262,6 +262,9 @@ body.bp {
           margin-right: 10px;
         }
       }
+      span.no-map-match-message {
+        color: red;
+      }
     }
 
     th {

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -69,6 +69,14 @@ class Collection < ActiveRecord::Base
 
   before_save :check_complete
 
+  def has_default_map_boundaries?
+    if (north_limit == 80.0) && (south_limit == -80.0) && (east_limit == -40.0) && (west_limit == -20.0)
+      true
+    else
+      false
+    end
+  end
+
   def check_complete
     present = [
       :identifier, :title, :description, :collector, :university,

--- a/app/views/collections/_form.html.haml
+++ b/app/views/collections/_form.html.haml
@@ -102,6 +102,11 @@
       %tr
         %th
         %td
+          %strong.left
+            - if @collection.has_default_map_boundaries?
+              %span.no-map-match-message No matching map data found
+            - else
+              %span.no-map-match-message
           %strong.right= link_to 'Set map from country', '#', :id => 'set-map-from-country'
           %strong.right= link_to 'Set map from language', '#', :id => 'set-map-from-language'
 


### PR DESCRIPTION
As can be seen from the commits, there are three changes:

* Add no map match message to collections, as well as to item. That's so that when the boundaries aren't changed on that page, users will know why.
* Make the no map match message more specific. That's so that when someone tries both setting by country, and by language, they'll get changing error messages. That indicates that the website itself is at least trying to fulfill their request, rather than there being a bug in the website.
* Don't change boundaries when there is no boundary information.

To review:

* collection.rb has a method copied from item.rb . Ideally, I'd like to create some sort of functionality for location, but I don't like modules, so unless there's a better solution, copying seems to be the way to go.
* This is my first time using coffeescript. I think the changes are ok, but I'm more likely to have a mistake there than in the haml or the model.