### PR TITLE
Fix #413 alert users when map is absent

### DIFF
--- a/app/assets/stylesheets/_layout_style.css.scss
+++ b/app/assets/stylesheets/_layout_style.css.scss
@@ -246,7 +246,7 @@ body.bp {
 
       &.missing {
         font-style: italic;
-        font-color: red;
+        color: red;
       }
 
       &.append {


### PR DESCRIPTION
This fixes a SCSS bug from a79ac305083b3345ef4fb0cd49782965bb8a7a85 . This will make the lack of a map more obvious.

I had a go at looking for tools to check SCSS for errors. I came across scss-lint, and it picked up this error, but it gives far too many other errors.

To review:

* This shows it in red to people who aren't able to edit the item or collection.
* I think this is a good way of indicating a map is absent, but I'd like your opinion.
