### PR TITLE
Preparatory bugfixes

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -80,8 +80,6 @@ class CollectionsController < ApplicationController
 
   def edit
     @num_items = @collection.items.count
-    @num_items_ready = @collection.items.where{ digitised_on != nil }.count
-    @num_essences = Essence.where(:item_id => @collection.items).count
 
     @items = @collection.items.order(:identifier).page(params[:items_page]).per(params[:items_per_page])
   end
@@ -131,6 +129,9 @@ class CollectionsController < ApplicationController
       flash[:notice] = 'Collection was successfully updated.'
       redirect_to @collection
     else
+      @num_items = @collection.items.count
+
+      @items = @collection.items.order(:identifier).page(params[:items_page]).per(params[:items_per_page])
       render :action => "edit"
     end
   end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -179,6 +179,7 @@ class CollectionsController < ApplicationController
     end
 
     if invalid_record
+      @collection = Collection.new
       do_search
       render :action => 'bulk_edit'
     else


### PR DESCRIPTION
This contains preparatory bugfixes for work on #457 . It ensures that if a save or update doesn't work, view rendering doesn't cause an exception because of a nil object.

To review: I also got rid of setting of `@num_items_ready`and `@num_essences`. They are redundant, aren't they?