### PR TITLE
Add batch jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,9 @@ gem 'rake'
 # Image processing
 gem 'rmagick'
 
+# Scheduling
+gem 'whenever', :require => false
+
 group :development, :test do
   gem 'turn', '~> 0.8.3', :require => false
   gem 'rspec-rails', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
       timers (~> 1.1.0)
     childprocess (0.3.8)
       ffi (~> 1.0, >= 1.0.11)
+    chronic (0.10.2)
     chunky_png (1.2.7)
     coderay (1.1.0)
     coffee-rails (3.2.2)
@@ -352,6 +353,8 @@ GEM
     warden (1.2.3)
       rack (>= 1.0)
     websocket (1.0.7)
+    whenever (0.9.4)
+      chronic (>= 0.6.3)
     xpath (0.1.4)
       nokogiri (~> 1.3)
 
@@ -417,3 +420,4 @@ DEPENDENCIES
   turn (~> 0.8.3)
   uglifier (>= 1.0.3)
   unicorn
+  whenever

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,7 +173,7 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.3.0)
       launchy (~> 2.2)
-    libv8 (3.16.14.3)
+    libv8 (3.16.14.11)
     listen (2.4.0)
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)

--- a/app/services/batch_doi_minting_service.rb
+++ b/app/services/batch_doi_minting_service.rb
@@ -1,0 +1,28 @@
+# Batch minting of DOIs.
+# For an individual minting, see DoiMintingService.
+class BatchDoiMintingService
+  def self.run(batch_size)
+    batch_doi_minting_service = new(batch_size)
+    batch_doi_minting_service.run
+  end
+
+  def initialize(batch_size)
+    @batch_size = batch_size
+    @doi_minting_service = create_doi_minting_service
+    @unminted_objects = find_unminted_objects
+  end
+
+  def create_doi_minting_service
+    DoiMintingService.new('json')
+  end
+
+  def find_unminted_objects
+    Collection.where(doi: nil).limit(@batch_size)
+  end
+
+  def run
+    @unminted_objects.each do |unminted_object|
+      @doi_minting_service.mint_doi(unminted_object)
+    end
+  end
+end

--- a/app/services/doi_minting_service.rb
+++ b/app/services/doi_minting_service.rb
@@ -31,6 +31,7 @@ class DoiMintingService
       content = JSON.parse(response.body)
       if content['response']['responsecode'] == AndsResponse::MINTING_SUCCESS
         doiable.doi = content['response']['doi']
+        doiable.save!
         puts "Successfully minted DOI for #{doiable.full_path} => #{doiable.doi}"
       else
         puts "Failed to mint DOI - DOI minting return a bad response: #{content['response']['responsecode']} / #{content['response']['message']}"

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,1 @@
+# Use this file to easily define all of your cron jobs.

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,1 +1,5 @@
 # Use this file to easily define all of your cron jobs.
+
+every 1.day, :at => '4:30 am' do
+  rake "archive:mint_dois"
+end

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -286,6 +286,11 @@ namespace :archive do
     end
   end
 
+  desc "Mint DOIs for objects that don't have one"
+  task :mint_dois => :environment do
+    batch_size = Integer(ENV['MINT_DOIS_BATCH_SIZE'])
+    BatchDoiMintingService.run(batch_size)
+  end
 
   # HELPERS
 


### PR DESCRIPTION
This creates batch jobs using the background job gem delayed_job, and the scheduling gem whenever.

I chose delayed_job because it's one of the simpler background job gems, as it doesn't require redis being installed. resque has a [comparison](https://github.com/resque/resque/blob/1-x-stable/README.markdown#resque-vs-delayedjob) of resque and delayed_job, which describes delayed_job as simpler.

I chose whenever because it's the most popular gem in "Scheduling" in the Ruby toolbox.

This adds the rake task `archive:mint_dois`, and the environment variable `MINT_DOIS_BATCH_SIZE`.

To create the cron syntax for the running of `archive:mint_dois`, enter the project directory and run `bundle exec whenever`.

I haven't edited any cron files, nor started a background process for working off of jobs. I assume that's a task better left to @JonoGillett .