### PR TITLE
Fix #452 search failure for long words

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -113,7 +113,7 @@ class Collection < ActiveRecord::Base
   searchable do
     # Things we want to perform full text search on
     text :title
-    text :identifier, :as => :code_textp
+    text :identifier, :as => :identifier_textp
     text :identifier2 do
       identifier
     end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -193,8 +193,8 @@ class Item < ActiveRecord::Base
   searchable do
     # Things we want to perform full text search on
     text :title
-    text :identifier, :as => :code_textp
-    text :full_identifier, :as => :code_textp
+    text :identifier, :as => :identifier_textp
+    text :full_identifier, :as => :full_identifier_textp
     text :collector_name
     text :university_name
     text :operator_name

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -64,7 +64,7 @@
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.StandardFilterFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.EdgeNGramFilterFactory" minGramSize="2" maxGramSize="10" side="front"/>
+        <filter class="solr.EdgeNGramFilterFactory" minGramSize="2" maxGramSize="200" side="front"/>
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.StandardTokenizerFactory"/>

--- a/spec/features/search_items_spec.rb
+++ b/spec/features/search_items_spec.rb
@@ -34,7 +34,6 @@ describe 'Item Search', search: true do
         context 'using a full keyword' do
           let(:search_term) { identifier }
           it 'should have a match' do
-            pending 'Fails because maxGramSize is 10'
             expect(search.results.length).to eq 1
           end
         end
@@ -42,7 +41,6 @@ describe 'Item Search', search: true do
         context 'using a partial keyword' do
           let(:search_term) { identifier[0..-2] }
           it 'should have a match' do
-            pending 'Fails because maxGramSize is 10'
             expect(search.results.length).to eq 1
           end
         end
@@ -74,7 +72,6 @@ describe 'Item Search', search: true do
         context 'using a full keyword' do
           let(:search_term) { item.full_identifier }
           it 'should have a match' do
-            pending 'Fails because maxGramSize is 10'
             expect(search.results.length).to eq 1
           end
         end
@@ -82,7 +79,6 @@ describe 'Item Search', search: true do
         context 'using a partial keyword' do
           let(:search_term) { item.full_identifier[0..-2] }
           it 'should have a match' do
-            pending 'Fails because maxGramSize is 10'
             expect(search.results.length).to eq 1
           end
         end

--- a/spec/features/search_items_spec.rb
+++ b/spec/features/search_items_spec.rb
@@ -1,103 +1,108 @@
 require 'spec_helper'
 describe 'Item Search', search: true do
-  let!(:country1) {create(:country)}
-  let!(:country2) {create(:country)}
-  let!(:item1) {create(:item, countries: [country1])}
-  let!(:item2) {create(:item, countries: [country2])}
-
-  let!(:user) {create(:user)}
-
-  before(:all) do
-    Sunspot.remove_all!(Item)
-    Sunspot.index!(item1, item2)
+  describe 'Solr searching of items' do
   end
 
-  context 'when user is not signed in' do
-    context 'viewing the page' do
+  describe 'ItemsController use of Item Search' do
+    let!(:country1) {create(:country)}
+    let!(:country2) {create(:country)}
+    let!(:item1) {create(:item, countries: [country1])}
+    let!(:item2) {create(:item, countries: [country2])}
+
+    let!(:user) {create(:user)}
+
+    before(:all) do
+      Sunspot.remove_all!(Item)
+      Sunspot.index!(item1, item2)
+    end
+
+    context 'when user is not signed in' do
+      context 'viewing the page' do
+        before do
+          visit search_items_path
+        end
+        it 'should not show advanced search' do
+          expect(page).to_not have_content('Advanced Search')
+        end
+        it 'should show all items' do
+          expect(page).to_not have_content('NO results')
+          expect(page).to have_content(item1.identifier)
+        end
+      end
+    end
+
+    context 'when user is signed in' do
       before do
+        login_as user, scope: :user
         visit search_items_path
       end
-      it 'should not show advanced search' do
-        expect(page).to_not have_content('Advanced Search')
-      end
-      it 'should show all items' do
-        expect(page).to_not have_content('NO results')
-        expect(page).to have_content(item1.identifier)
-      end
-    end
-  end
 
-  context 'when user is signed in' do
-    before do
-      login_as user, scope: :user
-      visit search_items_path
-    end
-
-    context 'viewing the page' do
-      it 'should show advanced search' do
-        expect(page).to have_content('Advanced Search')
-      end
-    end
-    context 'running a search' do
-      context 'when selecting from the filter lists' do
-        it 'should filter other lists as well' do
-          uri = URI.parse(current_url).request_uri.to_s
-          uri += "#{uri.include?('?') ? '&' : '?'}country_id=#{country1.id}"
-
-          expect(page).to have_content(country2.name)
-
-          click_link country1.name
-
-          expect(URI.parse(current_url).request_uri).to eq(uri)
-          expect(page).to_not have_content(country2.name)
-        end
-        it 'should perform search immediately' do
-          expect(page).to have_content('2 search results')
-
-          click_link country1.name
-
-          expect(page).to have_content('1 search result')
+      context 'viewing the page' do
+        it 'should show advanced search' do
+          expect(page).to have_content('Advanced Search')
         end
       end
-      context 'when searching by keyword' do
-        #TODO: Fix this so that the required: true on the page actually stops this, rather than getting bypassed
-        # context 'with no value' do
-        #   it 'should maintain current search' do
-        #     click_link country1.name
-        #     expect(page).to_not have_content(country2.name)
-        #
-        #     fill_in 'search', with: nil
-        #     click_button 'Search'
-        #
-        #     expect(page).to_not have_content(country2.name)
-        #   end
-        # end
-        context 'with a value' do
-          it 'should remove facet filters' do
-            click_link country1.name
-            expect(page).to_not have_content(country2.name)
-            fill_in 'search', with: item2.identifier
-            click_button 'Search'
-            sleep 1
+      context 'running a search' do
+        context 'when selecting from the filter lists' do
+          it 'should filter other lists as well' do
+            uri = URI.parse(current_url).request_uri.to_s
+            uri += "#{uri.include?('?') ? '&' : '?'}country_id=#{country1.id}"
 
             expect(page).to have_content(country2.name)
-            expect(page).to_not have_content(country1.name)
+
+            click_link country1.name
+
+            expect(URI.parse(current_url).request_uri).to eq(uri)
+            expect(page).to_not have_content(country2.name)
+          end
+          it 'should perform search immediately' do
+            expect(page).to have_content('2 search results')
+
+            click_link country1.name
+
+            expect(page).to have_content('1 search result')
           end
         end
-      end
-      context 'when clearing the search' do
-        it 'should remove all params and reset search' do
-          expect(page).to have_content(country2.name)
+        context 'when searching by keyword' do
+          #TODO: Fix this so that the required: true on the page actually stops this, rather than getting bypassed
+          # context 'with no value' do
+          #   it 'should maintain current search' do
+          #     click_link country1.name
+          #     expect(page).to_not have_content(country2.name)
+          #
+          #     fill_in 'search', with: nil
+          #     click_button 'Search'
+          #
+          #     expect(page).to_not have_content(country2.name)
+          #   end
+          # end
+          context 'with a value' do
+            it 'should remove facet filters' do
+              click_link country1.name
+              expect(page).to_not have_content(country2.name)
+              fill_in 'search', with: item2.identifier
+              click_button 'Search'
+              sleep 1
 
-          click_link country1.name
+              expect(page).to have_content(country2.name)
+              expect(page).to_not have_content(country1.name)
+            end
+          end
+        end
+        context 'when clearing the search' do
+          it 'should remove all params and reset search' do
+            expect(page).to have_content(country2.name)
 
-          expect(page).to_not have_content(country2.name)
+            click_link country1.name
 
-          click_button 'Clear'
+            expect(page).to_not have_content(country2.name)
 
-          expect(page).to have_content(country2.name)
+            click_button 'Clear'
 
-          expect(URI.parse(current_url).request_uri).to end_with('search') # no query params
+            expect(page).to have_content(country2.name)
+
+            expect(URI.parse(current_url).request_uri).to end_with('search') # no query params
+          end
         end
       end
     end


### PR DESCRIPTION
This fixes #452 with regards to not finding "NT5-TokelauThatch".

The problem was that the search term was longer than 10 characters, which was the previously set limit. This is the same problem as faced in #260 .

code_textp was replaced with some more logical identifiers. However, I couldn't find any sign that the use of code_textp caused any problems.

#468 is the same as this pull request, except it had the wrong merge target.