### PR TITLE
Fix #471

### DIFF
--- a/app/controllers/essences_controller.rb
+++ b/app/controllers/essences_controller.rb
@@ -6,7 +6,10 @@ class EssencesController < ApplicationController
   def show
     @page_title = "Nabu - #{@essence.filename} (#{@essence.item.title})"
     unless can? :manage, @essence
-      if ['Open (subject to agreeing to PDSC access conditions)', 'Open (subject to the access condition details)'].include? @essence.item.access_condition.name
+      if @essence.item.access_condition.nil?
+        flash[:error] = 'Item does not have data access conditions set'
+        redirect_to [@collection, @item]
+      elsif ['Open (subject to agreeing to PDSC access conditions)', 'Open (subject to the access condition details)'].include? @essence.item.access_condition.name
         unless session["terms_#{@collection.id}"] == true
           redirect_to show_terms_collection_item_essence_path
         end

--- a/spec/controllers/essences_controller_spec.rb
+++ b/spec/controllers/essences_controller_spec.rb
@@ -5,7 +5,8 @@ describe EssencesController, type: :controller do
   let(:manager) {create(:user, admin: true)}
 
   let(:collection) {create(:collection)}
-  let(:item) {create(:item, collection: collection, access_condition: AccessCondition.new({name: 'Open (subject to agreeing to PDSC access conditions)'}))}
+  let(:access_condition) { AccessCondition.new({name: 'Open (subject to agreeing to PDSC access conditions)'}) }
+  let(:item) {create(:item, collection: collection, access_condition: access_condition)}
   let(:essence) {create(:sound_essence, item: item)}
 
   let(:params) { {collection_id: collection.identifier, item_id: item.identifier, id: essence.id} }
@@ -64,6 +65,18 @@ describe EssencesController, type: :controller do
           expect(response.status).to eq(200)
           expect(response).to render_template(:show)
           expect(flash[:error]).to be_nil
+        end
+      end
+
+      context 'when access_condition_id nil' do
+        let(:access_condition) { nil }
+
+        it 'should redirect to show item page with error' do
+          pending 'Pending spec'
+          get :show, params
+          expect(session).to_not have_key("terms_#{collection.id}")
+          expect(response).to redirect_to(params.reject{|x,y| x == :item_id}.merge(id: item.identifier, controller: :items, action: :show))
+          expect(flash[:error]).to eq 'Item does not have data access conditions set'
         end
       end
     end

--- a/spec/controllers/essences_controller_spec.rb
+++ b/spec/controllers/essences_controller_spec.rb
@@ -72,7 +72,6 @@ describe EssencesController, type: :controller do
         let(:access_condition) { nil }
 
         it 'should redirect to show item page with error' do
-          pending 'Pending spec'
           get :show, params
           expect(session).to_not have_key("terms_#{collection.id}")
           expect(response).to redirect_to(params.reject{|x,y| x == :item_id}.merge(id: item.identifier, controller: :items, action: :show))

--- a/spec/controllers/essences_controller_spec.rb
+++ b/spec/controllers/essences_controller_spec.rb
@@ -10,7 +10,7 @@ describe EssencesController, type: :controller do
 
   let(:params) { {collection_id: collection.identifier, item_id: item.identifier, id: essence.id} }
 
-  before(:all) do
+  before(:each) do
     # allow test user to access everything
     item.item_users << ItemUser.new({item: item, user: user})
   end


### PR DESCRIPTION
Fixes #471 .

This is a bit imperfect. Ideally, we'd validate that all items have a non-nil `access_condition`, and fix all existing items that had a nil `access_condition`.

Also, I wasn't able to reproduce it locally. Maybe I had to be a member of item_users without being a creator of a work.

To review:

* Is it ok to show an error message when the user (ie the person viewing the image) didn't do anything wrong?