### PR TITLE
Fix #419 and #490

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -202,6 +202,12 @@ class CollectionsController < ApplicationController
   end
 
   def create_from_exsite9
+    unless params.key?(:collection)
+      @collection = Collection.new unless @collection
+      flash[:error] = 'No ExSite9 file submitted'
+      render 'new_from_metadata'
+      return
+    end
     # get XML data
     data = params[:collection][:metadata].read
     # parse XML file as ExSite9
@@ -223,6 +229,12 @@ class CollectionsController < ApplicationController
   end
 
   def create_from_spreadsheet
+    unless params.key?(:collection)
+      @collection = Collection.new unless @collection
+      flash[:error] = 'No Spreadsheet XLS file submitted'
+      render 'new_from_metadata'
+      return
+    end
     # get XSL data
     data = params[:collection][:metadata].read
     # parse XML file as Spreadsheet

--- a/lib/nabu_spreadsheet.rb
+++ b/lib/nabu_spreadsheet.rb
@@ -13,7 +13,12 @@ module Nabu
     def parse(data, current_user)
       # open Spreadsheet as "file"
       s = StringIO.new data
-      book = Spreadsheet.open s
+      begin
+        book = Spreadsheet.open s
+      rescue Ole::Storage::FormatError => _e
+        @errors << "ERROR XLSX file provided - please supply an XLS file (the older Excel file format) instead"
+        return
+      end
       sheet1 = book.worksheet 0
 
       # parse collection in XSL file

--- a/lib/nabu_spreadsheet.rb
+++ b/lib/nabu_spreadsheet.rb
@@ -171,8 +171,8 @@ module Nabu
 
       first_name, last_name = name.split(',').map(&:strip)
 
-      if last_name.nil?
-        last_name = ''
+      if last_name == ''
+        last_name = nil
       end
 
       user = User.where(first_name: first_name, last_name: last_name).first


### PR DESCRIPTION
Fix #419 (spreadsheet upload) and #470 (Collector not showing up).

"Collector not showing up" was fixed by doing a search for users using a `last_name` of `nil`, not `''`.

"Spreadsheet upload" was fixed by giving an informative message when a user has supplied the wrong file format (such as XLSX) when an XLS file is required.

As an added bonus, I've given a useful error message if someone's forgotten to submit a spreadsheet. This will fix Rollbar error 81.

To review:

* Does the error message "ERROR XLSX file provided - please supply an XLS file (the older Excel file format) instead" sound good, in terms of being easily understood by non-technical people?
* I'm actually cheating - if the user submitted an MP3 file, they'd still be told "ERROR XLSX file ...". I assume that so long as the user knows what the general problem is, then it doesn't matter that it's not 100% true. Is that ok?