### PR TITLE
Fix #488 language list is wrong

### DIFF
--- a/app/admin/languages.rb
+++ b/app/admin/languages.rb
@@ -3,6 +3,16 @@ ActiveAdmin.register Language do
   config.sort_order = "name"
   actions :all, :except => [:destroy]
 
+  filter :countries
+  filter :items_for_content
+  filter :items_for_subject
+  filter :collections
+  filter :code
+  filter :name
+  filter :retired
+  # Don't filter by north_limit, east_limit, south_limit or west_limit .
+  # No strong business case for doing so.
+
   # show page
   show do |language|
     attributes_table  do

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -30,10 +30,10 @@ class Language < ActiveRecord::Base
   #validates :countries, :length => { :minimum => 1 }
 
   has_many :item_content_languages
-  has_many :items, :through => :item_content_languages, :dependent => :restrict
+  has_many :items_for_content, :through => :item_content_languages, :source => :item, :dependent => :restrict
 
   has_many :item_subject_languages
-  has_many :items, :through => :item_subject_languages, :dependent => :restrict
+  has_many :items_for_subject, :through => :item_subject_languages, :source => :item, :dependent => :restrict
 
   has_many :collection_languages
   has_many :collections, :through => :collection_languages, :dependent => :restrict


### PR DESCRIPTION
Fix #488 "language list is wrong". Fixed by not having as filters join table records, and having `has_many :items_for_content` different from `has_many :items_for_subject`.

I don't anticipate any problems with this pull request.