### PR TITLE
Fix #484 search fail. Caused by using the wrong parameter.

### DIFF
--- a/app/views/items/advanced_search.html.haml
+++ b/app/views/items/advanced_search.html.haml
@@ -31,8 +31,8 @@
 
       %table.form
         %tr
-          %th= label_tag :identifier, 'Item ID'
-          %td= text_field_tag :identifier, params[:identifier], :class => 'short'
+          %th= label_tag :full_identifier, 'Item ID'
+          %td= text_field_tag :full_identifier, params[:full_identifier], :class => 'short'
 
         %tr
           %th


### PR DESCRIPTION
Fix #484 "Search fail".

I checked if there was any potential for the problem that happened (using the wrong parameter) to be occurring elsewhere in the codebase. I couldn't find anything definitely wrong.