### PR TITLE
Fix issue with zero degrees north_limit. Mentioned in #453 comment.

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -246,9 +246,9 @@ class Collection < ActiveRecord::Base
   end
 
   def has_coordinates
-    (north_limit && north_limit != 0) &&
-    (south_limit && south_limit != 0) &&
-    (west_limit && west_limit != 0) &&
+    (north_limit && north_limit != 0) ||
+    (south_limit && south_limit != 0) ||
+    (west_limit && west_limit != 0) ||
     (east_limit && east_limit != 0)
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -385,9 +385,9 @@ class Item < ActiveRecord::Base
   end
 
   def has_coordinates
-    (north_limit && north_limit != 0) &&
-    (south_limit && south_limit != 0) &&
-    (west_limit && west_limit != 0) &&
+    (north_limit && north_limit != 0) ||
+    (south_limit && south_limit != 0) ||
+    (west_limit && west_limit != 0) ||
     (east_limit && east_limit != 0)
   end
 


### PR DESCRIPTION
Fix bug which occurred during past refactoring.

It caused any item or collection that had one of its compass direction limits of zero degrees to be mistakenly described as lacking coordinates. This affected items with its limits set by Vanuatu's boundaries.