### PR TITLE
Feature/doi improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .bundle
+.ruby-version
+.idea/
 db/*.sqlite3
 log/*
 solr/data

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -231,6 +231,11 @@ class Collection < ActiveRecord::Base
     "paradisec.org.au/collection/#{identifier}"
   end
 
+  # for DOI relationship linking: nil <- Collection <- Item <- Essence
+  def parent
+    nil
+  end
+
   def citation
     cite = ""
     if collector

--- a/app/models/essence.rb
+++ b/app/models/essence.rb
@@ -92,4 +92,8 @@ class Essence < ActiveRecord::Base
     item.collection.collector_name
   end
 
+  # for DOI relationship linking: nil <- Collection <- Item <- Essence
+  def parent
+    item
+  end
 end

--- a/app/models/identifiable_by_doi.rb
+++ b/app/models/identifiable_by_doi.rb
@@ -12,13 +12,13 @@ module IdentifiableByDoi
       xml.tag! 'titles' do
         xml.tag! 'title', title
       end
-      xml.tag! 'publisher', collector_name
+      xml.tag! 'publisher', 'PARADISEC'
       # Items are the only type which contain the true publication date, so prefer that, but fall back to the date it was added to Nabu
       xml.tag! 'publicationYear', (respond_to?(:originated_on) ? try(:originated_on) : created_at).year
 
       xml.tag! 'contributors' do
-        xml.tag! 'contributor', contributorType: 'HostingInstitution' do
-          xml.tag! 'contributorName', 'PARADISEC'
+        xml.tag! 'contributor', contributorType: 'DataCollector' do
+          xml.tag! 'contributorName', collector_name
         end
 
         if respond_to?(:university_name)

--- a/app/models/identifiable_by_doi.rb
+++ b/app/models/identifiable_by_doi.rb
@@ -15,8 +15,17 @@ module IdentifiableByDoi
       xml.tag! 'publisher', 'PARADISEC'
       # Items are the only type which contain the true publication date, so prefer that, but fall back to the date it was added to Nabu
       xml.tag! 'publicationYear', (respond_to?(:originated_on) ? try(:originated_on) : created_at).year
+
+      if respond_to?(:university_name)
+        xml.tag! 'contributors' do
+          xml.tag! 'contributor', contributorType: 'DataCollector' do
+            xml.tag! 'contributorName', university_name
+          end
+        end
+      end
+
       # parent should exist for everything except Collection
-      unless  parent.nil?
+      if parent.present?
         xml.tag! 'relatedIdentifiers' do
           xml.tag! 'relatedIdentifier', parent.doi, relatedIdentifierType: 'DOI', relationType: is_a?(Item) ? 'IsPartOf' : 'IsSourceOf'
         end

--- a/app/models/identifiable_by_doi.rb
+++ b/app/models/identifiable_by_doi.rb
@@ -12,12 +12,16 @@ module IdentifiableByDoi
       xml.tag! 'titles' do
         xml.tag! 'title', title
       end
-      xml.tag! 'publisher', 'PARADISEC'
+      xml.tag! 'publisher', collector_name
       # Items are the only type which contain the true publication date, so prefer that, but fall back to the date it was added to Nabu
       xml.tag! 'publicationYear', (respond_to?(:originated_on) ? try(:originated_on) : created_at).year
 
-      if respond_to?(:university_name)
-        xml.tag! 'contributors' do
+      xml.tag! 'contributors' do
+        xml.tag! 'contributor', contributorType: 'HostingInstitution' do
+          xml.tag! 'contributorName', 'PARADISEC'
+        end
+
+        if respond_to?(:university_name)
           xml.tag! 'contributor', contributorType: 'DataCollector' do
             xml.tag! 'contributorName', university_name
           end

--- a/app/models/identifiable_by_doi.rb
+++ b/app/models/identifiable_by_doi.rb
@@ -12,8 +12,15 @@ module IdentifiableByDoi
       xml.tag! 'titles' do
         xml.tag! 'title', title
       end
-      xml.tag! 'publisher', collector_name
-      xml.tag! 'publicationYear', created_at.year
+      xml.tag! 'publisher', 'PARADISEC'
+      # Items are the only type which contain the true publication date, so prefer that, but fall back to the date it was added to Nabu
+      xml.tag! 'publicationYear', (respond_to?(:originated_on) ? try(:originated_on) : created_at).year
+      # parent should exist for everything except Collection
+      unless  parent.nil?
+        xml.tag! 'relatedIdentifiers' do
+          xml.tag! 'relatedIdentifier', parent.doi, relatedIdentifierType: 'DOI', relationType: is_a?(Item) ? 'IsPartOf' : 'IsSourceOf'
+        end
+      end
     end
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -158,6 +158,11 @@ class Item < ActiveRecord::Base
     "http://catalog.paradisec.org.au/collections/#{collection.identifier}/items/#{identifier}"
   end
 
+  # for DOI relationship linking: nil <- Collection <- Item <- Essence
+  def parent
+    collection
+  end
+
   def path
     basepath = Nabu::Application.config.archive_directory + '/' + collection.identifier + '/' + identifier + '/'
     filename = "#{full_identifier}-CAT-PDSC_ADMIN.xml"

--- a/app/services/batch_doi_minting_service.rb
+++ b/app/services/batch_doi_minting_service.rb
@@ -16,6 +16,8 @@ class BatchDoiMintingService
     DoiMintingService.new('json')
   end
 
+  # The way this find works ensures that the minting occurs in a top-down manner allowing for
+  # Items and Essences to reference their parent records by DOI
   def find_unminted_objects
     (Collection.where(doi: nil).limit(@batch_size) + Item.where(doi: nil).limit(@batch_size) + Essence.where(doi: nil).limit(@batch_size)).first(@batch_size)
   end

--- a/spec/factories/collection.rb
+++ b/spec/factories/collection.rb
@@ -14,5 +14,9 @@ FactoryGirl.define do
     collector
     created_at Date.parse('2015/01/01')
     private false
+
+    trait :with_doi do
+      sequence(:doi) {|n| "doi:TEST#{n}"}
+    end
   end
 end

--- a/spec/factories/collection.rb
+++ b/spec/factories/collection.rb
@@ -16,7 +16,7 @@ FactoryGirl.define do
     private false
 
     trait :with_doi do
-      sequence(:doi) {|n| "doi:TEST#{n}"}
+      sequence(:doi) {|n| "doi:COLLECTION#{n}"}
     end
   end
 end

--- a/spec/factories/essence.rb
+++ b/spec/factories/essence.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :essence do
-    item
+    item { build(:item, :with_doi) }
     created_at Date.parse('2015/01/01')
 
     factory :sound_essence do

--- a/spec/factories/item.rb
+++ b/spec/factories/item.rb
@@ -23,7 +23,7 @@ FactoryGirl.define do
     end
 
     trait :with_doi do
-      sequence(:doi) {|n| "doi:TEST#{n}"}
+      sequence(:doi) {|n| "doi:ITEM#{n}"}
     end
   end
 end

--- a/spec/factories/item.rb
+++ b/spec/factories/item.rb
@@ -12,7 +12,7 @@ FactoryGirl.define do
     west_limit "121.122"
     east_limit "122.046"
     discourse_type
-    collection
+    collection {build(:collection, :with_doi)}
     originated_on Date.today
     created_at Date.parse('2015/01/01')
     private false
@@ -20,6 +20,10 @@ FactoryGirl.define do
       item.countries ||= build_list(:country, 1)
       item.subject_languages = item.subject_languages.present? ? item.subject_languages : build_list(:language, 1)
       item.content_languages = item.content_languages.present? ? item.content_languages : build_list(:language, 1)
+    end
+
+    trait :with_doi do
+      sequence(:doi) {|n| "doi:TEST#{n}"}
     end
   end
 end

--- a/spec/models/doi_metadata_spec.rb
+++ b/spec/models/doi_metadata_spec.rb
@@ -19,6 +19,11 @@ describe IdentifiableByDoi do
         #but hopefully there aren't any
         expect(errors.count).to eq(0)
       end
+
+      it 'should include the originating university as a reference' do
+        doixml = collection.to_doi_xml
+        expect(doixml).to include(collection.university_name)
+      end
     end
   end
   context 'with item' do
@@ -41,6 +46,11 @@ describe IdentifiableByDoi do
       it 'should include the parent collection as a reference' do
         doixml = item.to_doi_xml
         expect(doixml).to include(item.collection.doi)
+      end
+
+      it 'should include the originating university as a reference' do
+        doixml = item.to_doi_xml
+        expect(doixml).to include(item.university_name)
       end
     end
   end

--- a/spec/models/doi_metadata_spec.rb
+++ b/spec/models/doi_metadata_spec.rb
@@ -37,6 +37,11 @@ describe IdentifiableByDoi do
         #but hopefully there aren't any
         expect(errors.count).to eq(0)
       end
+
+      it 'should include the parent collection as a reference' do
+        doixml = item.to_doi_xml
+        expect(doixml).to include(item.collection.doi)
+      end
     end
   end
 
@@ -55,6 +60,11 @@ describe IdentifiableByDoi do
         end
         #but hopefully there aren't any
         expect(errors.count).to eq(0)
+      end
+
+      it 'should include the parent item as a reference' do
+        doixml = essence.to_doi_xml
+        expect(doixml).to include(essence.item.doi)
       end
     end
   end


### PR DESCRIPTION
Fixes #379 based on the meeting with ANDS.

Changes are:
- using the origination date of an item where available
- including hierarchical DOI relationships
- including originating university and PARADISEC as contributors to enable DataCite searching