### PR TITLE
Rake task to change catalog XML for existing items

### DIFF
--- a/app/services/batch_item_catalog_service.rb
+++ b/app/services/batch_item_catalog_service.rb
@@ -1,0 +1,22 @@
+class BatchItemCatalogService
+  def self.run(offline_template)
+    batch_item_catalog_service = new(offline_template)
+    batch_item_catalog_service.run
+  end
+
+  def initialize(offline_template)
+    @offline_template = offline_template
+  end
+
+  def run
+    Item.find_each do |item|
+      process_item(item)
+    end
+  end
+
+  def process_item(item)
+    data = @offline_template.render_to_string :template => 'items/catalog_export.xml.haml', locals: {item: item}
+
+    ItemCatalogService.new(item).save_file(data)
+  end
+end

--- a/app/views/items/show.xml.haml
+++ b/app/views/items/show.xml.haml
@@ -74,7 +74,7 @@
     %userComments{:numComments => item.comments.count}
       - item.comments.each do |comment|
         %comment
-          %author= comment.owner.name
+          %author= comment.owner.name if comment.owner
           %description= comment.body
           %createdAt= comment.created_at
     -if content_for?(:collection_details)

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -302,6 +302,12 @@ namespace :archive do
     BatchImageTransformerService.run(batch_size)
   end
 
+  desc "Update catalog details of items"
+  task :update_item_catalogs => :environment do
+    offline_template = OfflineTemplate.new
+    BatchItemCatalogService.run(offline_template)
+  end
+
   # HELPERS
 
   def directories(path)


### PR DESCRIPTION
This pull request creates a rake task and service for changing the catalog XML for existing items.

To review:

* I had to add an `if comment.owner` to show.xml.haml . Does it look ok?
* I passed an `OfflineTemplate` object to the batch service (I used the term "batch" because multiple things are being done, even though the batch is *ALL* the items). Does that look ok?
