### PR TITLE
Fix private collection rights

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -26,7 +26,12 @@ class CollectionsController < ApplicationController
       with(:country_ids, params[:country_id]) if params[:country_id].present?
       with(:collector_id, params[:collector_id]) if params[:collector_id].present?
 
-      with(:private, false) unless current_user && current_user.admin?
+      unless current_user && current_user.admin?
+        any_of do
+          with(:private, false)
+          with(:admin_ids, current_user.id) if current_user
+        end
+      end
       sort_column(Collection).each do |c|
         order_by c, sort_direction
       end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -371,7 +371,12 @@ class CollectionsController < ApplicationController
         end
       end
 
-      with(:private, false) unless current_user && current_user.admin?
+      unless current_user && current_user.admin?
+        any_of do
+          with(:private, false)
+          with(:admin_ids, current_user.id) if current_user
+        end
+      end
       sort_column(Collection).each do |c|
         order_by c, sort_direction
       end

--- a/spec/features/search_collections_spec.rb
+++ b/spec/features/search_collections_spec.rb
@@ -124,9 +124,7 @@ describe 'Collection Search', search: true do
         let!(:private_collection) {create(:collection, countries: [country1], languages: [language], private: true, admins: [user])}
 
         it 'can be viewed by the user' do
-          pending do
-            expect(page).to have_content(private_collection.identifier)
-          end
+          expect(page).to have_content(private_collection.identifier)
         end
       end
     end


### PR DESCRIPTION
Fixes the two comments in #374 .

To review:

* I didn't do any automated testing for the advanced search
* The automated testing is a bit brittle. For example, I had to copy some `before` code for the `'user has edit rights'` context. Is that normal for these kinds of tests?
