### PR TITLE
Issue #510: Give informative error when file doesn't exist

### DIFF
--- a/app/controllers/essences_controller.rb
+++ b/app/controllers/essences_controller.rb
@@ -18,6 +18,11 @@ class EssencesController < ApplicationController
   end
 
   def download
+    unless File.exist?(@essence.path)
+      flash[:error] = 'File not found'
+      redirect_to [@collection, @item, @essence]
+      return
+    end
     Download.create! :user => current_user, :essence => @essence
     send_file @essence.path, :type => @essence.mimetype, :filename => @essence.filename
   end


### PR DESCRIPTION
Give an informative error when a file doesn't exist.

The other part of fixing #510 will be fixing the filename.