### PR TITLE
Feature/nabu 347

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem 'quiet_assets'
 gem 'roo', '~> 2.1.0'
 # Unpublished version used for ability to use StringIO. https://github.com/roo-rb/roo-xls/pull/7
 gem 'roo-xls', :github => 'roo-rb/roo-xls', :ref => '0a5ef88'
+gem 'streamio-ffmpeg'
 gem 'rake'
 
 # Image processing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -345,6 +345,7 @@ GEM
       activerecord (~> 3.0)
       activesupport (~> 3.0)
       polyamorous (~> 0.5.0)
+    streamio-ffmpeg (1.0.0)
     sunspot (1.3.3)
       pr_geohash (~> 1.0)
       rsolr (~> 1.0.7)
@@ -442,6 +443,7 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   squeel
+  streamio-ffmpeg
   sunspot_rails
   sunspot_solr
   therubyracer

--- a/app/services/batch_transcode_essence_file_service.rb
+++ b/app/services/batch_transcode_essence_file_service.rb
@@ -1,0 +1,25 @@
+# Batch transcoding of essence files
+class BatchTranscodeEssenceFileService
+  def self.run(batch_size)
+    batch_transcode_essence_file_service = new(batch_size)
+    batch_transcode_essence_file_service.run
+  end
+
+  def initialize(batch_size)
+    @batch_size = batch_size
+    @essence_transcode_count = 0
+  end
+
+  def run
+    Item.find_each do |item|
+      break if @essence_transcode_count >= @batch_size
+      process_item(item)
+    end
+  end
+
+  def process_item(item)
+    transcode_essence_file_service = TranscodeEssenceFileService.new(item)
+    transcode_essence_file_service.run
+    @essence_transcode_count += transcode_essence_file_service.essence_transcode_count
+  end
+end

--- a/app/services/transcode_essence_file_service.rb
+++ b/app/services/transcode_essence_file_service.rb
@@ -1,0 +1,60 @@
+require 'media'
+
+# Transcode essence files for a single item
+class TranscodeEssenceFileService
+  include ActionView::Helpers::NumberHelper
+
+  attr_reader :essence_transcode_count
+
+  def self.run(item)
+    transcode_essence_file_service = new(item)
+    transcode_essence_file_service.run
+  end
+
+  def initialize(item)
+    @item = item
+    @essence_transcode_count = 0
+  end
+
+  def run
+    return unless @item.essences.where("mimetype like 'video/%'").any?
+
+    transcode_essences_to_video_webm
+  end
+
+  def transcode_essences_to_video_webm
+    @item.essences.where("mimetype like 'video/%'").each do |essence|
+      case essence.mimetype
+      when 'video/mp4', 'video/mpeg', 'video/quicktime', 'video/x-dv', 'video/x-msvideo'
+        transcode_to_video_webm(essence)
+      end
+    end
+  end
+
+  def transcode_to_video_webm(essence)
+    new_essence_filename = File.basename(essence.filename, '.*') + '.webm'
+    return if @item.essences.where(filename: new_essence_filename).any?
+    new_essence = Essence.new(:item => @item, :filename => new_essence_filename)
+    return unless File.exist?(essence.path)
+    movie = FFMPEG::Movie.new(essence.path)
+    movie.transcode(new_essence.path, '-c:v libvpx -qmin 0 -qmax 20 -crf 5 -b:v 2M -c:a libvorbis')
+    populate_essence_object(new_essence)
+  end
+
+  def populate_essence_object(essence)
+    media = Nabu::Media.new(essence.path)
+    fail unless media
+
+    essence.mimetype   = media.mimetype
+    essence.size       = media.size
+    essence.bitrate    = media.bitrate
+    essence.samplerate = media.samplerate
+    essence.duration   = number_with_precision(media.duration, :precision => 3)
+    essence.channels   = media.channels
+    essence.fps        = media.fps
+
+    fail unless essence.valid?
+    essence.save!
+    @essence_transcode_count += 1
+  end
+end

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -308,6 +308,12 @@ namespace :archive do
     BatchItemCatalogService.run(offline_template)
   end
 
+  desc "Transcode essence files into required formats"
+  task :transcode_essence_files => :environment do
+    batch_size = Integer(ENV['TRANSCODE_ESSENCE_FILES_BATCH_SIZE'] || 100)
+    BatchTranscodeEssenceFileService.run(batch_size)
+  end
+
   # HELPERS
 
   def directories(path)

--- a/spec/services/transcode_essence_file_service_spec.rb
+++ b/spec/services/transcode_essence_file_service_spec.rb
@@ -1,0 +1,208 @@
+require 'spec_helper'
+
+describe TranscodeEssenceFileService do
+  let(:transcode_essence_file_service) do
+    TranscodeEssenceFileService.new(item)
+  end
+  let(:collection) { create(:collection, identifier: collection_identifier) }
+  let(:item) { create(:item, collection: collection, identifier: item_identifier) }
+  let(:non_existent_file_essence) do
+    create(
+      :video_essence,
+      item: item,
+      filename: 'WRONG.mp4',
+      mimetype: 'video/mp4'
+    )
+  end
+  let(:video_mp4_essence) do
+    create(
+      :video_essence,
+      item: item,
+      filename: 'RB4-Vanuatu_Gasai-P8050224.mp4',
+      mimetype: 'video/mp4'
+    )
+  end
+  let(:video_mpeg_essence) do
+    create(
+      :video_essence,
+      item: item,
+      filename: 'LD1-v0435-A.mpg',
+      mimetype: 'video/mpeg'
+    )
+  end
+  let(:video_quicktime_essence) do
+    create(
+      :video_essence,
+      item: item,
+      filename: 'RD1-013-Blaro_11.mov',
+      mimetype: 'video/quicktime'
+    )
+  end
+  let(:video_x_dv_essence) do
+    create(
+      :video_essence,
+      item: item,
+      filename: 'NT5-StringBand-006.dv',
+      mimetype: 'video/x-dv'
+    )
+  end
+  let(:video_x_msvideo_essence) do
+    create(
+      :video_essence,
+      item: item,
+      filename: 'RB3-Mwaghavul-Video_Untitled.avi',
+      mimetype: 'video/x-msvideo'
+    )
+  end
+
+  context 'file referred to by essence object does not exist' do
+    let(:collection_identifier) { 'moot' }
+    let(:item_identifier) { 'moot' }
+    before do
+      Essence.destroy_all
+      Item.destroy_all
+      Collection.destroy_all
+      non_existent_file_essence
+      item.reload
+    end
+
+    it 'does not crash' do
+      expect{ transcode_essence_file_service.run }.to_not raise_error
+    end
+
+    it 'does not try to create an input movie object' do
+      FFMPEG::Movie.should_not_receive(:new)
+      transcode_essence_file_service.run
+    end
+  end
+
+  # public/system/nabu-archive/RB4/Vanuatu_Gasai/RB4-Vanuatu_Gasai-P8050224.mp4
+  context 'mp4 essence file exists' do
+    let(:collection_identifier) { 'RB4' }
+    let(:item_identifier) { 'Vanuatu_Gasai' }
+    describe 'created webm essence object' do
+      let(:created_essence_object) do
+        video_mp4_essence
+        item.reload
+        TranscodeEssenceFileService.run(item)
+        Essence.last
+      end
+
+      it 'has a mimetype of video/webm' do
+        pending unless File.exist?('public/system/nabu-archive/RB4/Vanuatu_Gasai/RB4-Vanuatu_Gasai-P8050224.mp4')
+        # Multiple expects in an `it` because it takes too long to run.
+        expect(created_essence_object.filename).to eq('RB4-Vanuatu_Gasai-P8050224.webm')
+        expect(created_essence_object.mimetype).to eq('video/webm')
+        expect(created_essence_object.bitrate > 0).to be true
+        expect(created_essence_object.samplerate > 0).to be true
+        expect(created_essence_object.duration > 0).to be true
+        expect(created_essence_object.channels > 0).to be true
+        expect(created_essence_object.fps > 0).to be true
+      end
+    end
+  end
+
+  # public/system/nabu-archive/LD1/v0435/LD1-v0435-A.mpg
+  context 'mpeg essence file exists' do
+    let(:collection_identifier) { 'LD1' }
+    let(:item_identifier) { 'v0435' }
+    describe 'created webm essence object' do
+      let(:created_essence_object) do
+        video_mpeg_essence
+        item.reload
+        TranscodeEssenceFileService.run(item)
+        Essence.last
+      end
+
+      it 'has a mimetype of video/webm' do
+        pending unless File.exist?('public/system/nabu-archive/LD1/v0435/LD1-v0435-A.mpg')
+        # Multiple expects in an `it` because it takes too long to run.
+        expect(created_essence_object.filename).to eq('LD1-v0435-A.webm')
+        expect(created_essence_object.mimetype).to eq('video/webm')
+        expect(created_essence_object.bitrate > 0).to be true
+        expect(created_essence_object.samplerate > 0).to be true
+        expect(created_essence_object.duration > 0).to be true
+        expect(created_essence_object.channels > 0).to be true
+        expect(created_essence_object.fps > 0).to be true
+      end
+    end
+  end
+
+  # public/system/nabu-archive/RD1/013/RD1-013-Blaro_11.mov
+  context 'quicktime essence file exists' do
+    let(:collection_identifier) { 'RD1' }
+    let(:item_identifier) { '013' }
+    describe 'created webm essence object' do
+      let(:created_essence_object) do
+        video_quicktime_essence
+        item.reload
+        TranscodeEssenceFileService.run(item)
+        Essence.last
+      end
+
+      it 'has a mimetype of video/webm' do
+        pending unless File.exist?('public/system/nabu-archive/RD1/013/RD1-013-Blaro_11.mov')
+        # Multiple expects in an `it` because it takes too long to run.
+        expect(created_essence_object.filename).to eq('RD1-013-Blaro_11.webm')
+        expect(created_essence_object.mimetype).to eq('video/webm')
+        expect(created_essence_object.bitrate > 0).to be true
+        expect(created_essence_object.samplerate > 0).to be true
+        expect(created_essence_object.duration > 0).to be true
+        expect(created_essence_object.channels > 0).to be true
+        expect(created_essence_object.fps > 0).to be true
+      end
+    end
+  end
+
+  # public/system/nabu-archive/NT5/StringBand/NT5-StringBand-006.dv
+  context 'x-dv essence file exists' do
+    let(:collection_identifier) { 'NT5' }
+    let(:item_identifier) { 'StringBand' }
+    describe 'created webm essence object' do
+      let(:created_essence_object) do
+        video_x_dv_essence
+        item.reload
+        TranscodeEssenceFileService.run(item)
+        Essence.last
+      end
+
+      it 'has a mimetype of video/webm' do
+        pending unless File.exist?('public/system/nabu-archive/NT5/StringBand/NT5-StringBand-006.dv')
+        # Multiple expects in an `it` because it takes too long to run.
+        expect(created_essence_object.filename).to eq('NT5-StringBand-006.webm')
+        expect(created_essence_object.mimetype).to eq('video/webm')
+        expect(created_essence_object.bitrate > 0).to be true
+        expect(created_essence_object.samplerate > 0).to be true
+        expect(created_essence_object.duration > 0).to be true
+        expect(created_essence_object.channels > 0).to be true
+        expect(created_essence_object.fps > 0).to be true
+      end
+    end
+  end
+
+  # public/system/nabu-archive/RB3/Mwaghavul/RB3-Mwaghavul-Video_Untitled.avi
+  context 'x-msvideo essence file exists' do
+    let(:collection_identifier) { 'RB3' }
+    let(:item_identifier) { 'Mwaghavul' }
+    describe 'created webm essence object' do
+      let(:created_essence_object) do
+        video_x_msvideo_essence
+        item.reload
+        TranscodeEssenceFileService.run(item)
+        Essence.last
+      end
+
+      it 'has a mimetype of video/webm' do
+        pending unless File.exist?('public/system/nabu-archive/RB3/Mwaghavul/RB3-Mwaghavul-Video_Untitled.avi')
+        # Multiple expects in an `it` because it takes too long to run.
+        expect(created_essence_object.filename).to eq('RB3-Mwaghavul-Video_Untitled.webm')
+        expect(created_essence_object.mimetype).to eq('video/webm')
+        expect(created_essence_object.bitrate > 0).to be true
+        expect(created_essence_object.samplerate > 0).to be true
+        expect(created_essence_object.duration > 0).to be true
+        expect(created_essence_object.channels > 0).to be true
+        expect(created_essence_object.fps > 0).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
Partial implementation of #347 "Introduce transcoding system for essence files".

This only converts videos into `'video/webm'` mimetype files. Currently I want to see how those conversions go before trying to convert videos into `'video/mp4'` mimetype files.

There's a bit of code duplication. That's because I assumed that the conversion task wouldn't be as straightforward as it has been so far.

I'd like to deploy this to production this afternoon if possible.

To review:

* Does the code look understandable?
* Any glaring problems?
* Should I somehow mark which files were generated by transcoding? (Not a problem with the current code: there's only one `'video/webm'` essence, so everything else with that mimetype will be known to be generated by my rake task)
