### PR TITLE
Fix #524 Sorting by modification date doesn't work

### DIFF
--- a/app/views/items/_search_results.html.haml
+++ b/app/views/items/_search_results.html.haml
@@ -8,7 +8,7 @@
     = sortable :collector_sortname, 'Collector'
     = sortable :language, 'Language as given'
     %th Countries
-    = sortable :modification_date
+    = sortable :updated_at, 'Modification Date'
     %th Actions
 
     - @search.each_hit_with_result do |hit, item|


### PR DESCRIPTION
Fixes the bug.

If you want to detect such bugs in the future, consider adding logging to `ApplicationController#sort_column`.