### PR TITLE
Fix #512 Language filters have been changed and are now wrong

### DIFF
--- a/app/admin/access_conditions.rb
+++ b/app/admin/access_conditions.rb
@@ -2,4 +2,9 @@ ActiveAdmin.register AccessCondition do
   menu :parent => "Other Entities"
   config.sort_order = "name"
   actions :all
+
+  # Don't filter by items or collections
+  filter :name
+  filter :created_at
+  filter :updated_at
 end

--- a/app/admin/agent_roles.rb
+++ b/app/admin/agent_roles.rb
@@ -4,6 +4,9 @@ ActiveAdmin.register AgentRole do
 
   before_destroy :check_dependent
 
+  # Don't filter by item_agents
+  filter :name
+
   controller do
     def check_dependent(object)
       if object.item_agents.count > 0

--- a/app/admin/countries.rb
+++ b/app/admin/countries.rb
@@ -2,4 +2,8 @@ ActiveAdmin.register Country do
   menu :parent => "Other Entities"
   config.sort_order = "name"
   actions :all, :except => [:destroy]
+
+  # Don't filter by countries_languages, languages, collection_languages, collections, or latlon boundaries
+  filter :code
+  filter :name
 end

--- a/app/admin/fields_of_research.rb
+++ b/app/admin/fields_of_research.rb
@@ -2,4 +2,8 @@ ActiveAdmin.register FieldOfResearch do
   menu :parent => "Other Entities"
   config.sort_order = "name"
   actions :all, :except => [:destroy]
+
+  # Don't filter by collections
+  filter :identifier
+  filter :name
 end

--- a/app/admin/funding_bodies.rb
+++ b/app/admin/funding_bodies.rb
@@ -4,6 +4,12 @@ ActiveAdmin.register FundingBody do
 
   before_destroy :check_dependent
 
+  # Don't filter by grants or collections
+  filter :name
+  filter :key_prefix
+  filter :created_at
+  filter :updated_at
+
   controller do
     def check_dependent(object)
       if object.collections.count > 0

--- a/app/admin/languages.rb
+++ b/app/admin/languages.rb
@@ -4,12 +4,11 @@ ActiveAdmin.register Language do
   actions :all, :except => [:destroy]
 
   filter :countries
-  filter :items_for_content
-  filter :items_for_subject
-  filter :collections
   filter :code
   filter :name
   filter :retired
+  # Don't filter by items_for_content, items_for_subject, or collections.
+  # Doesn't make sense.
   # Don't filter by north_limit, east_limit, south_limit or west_limit .
   # No strong business case for doing so.
 

--- a/app/admin/universities.rb
+++ b/app/admin/universities.rb
@@ -4,6 +4,12 @@ ActiveAdmin.register University do
 
   before_destroy :check_dependent
 
+  # Don't filter by collections of items
+  filter :name
+  filter :created_at
+  filter :updated_at
+  filter :party_identifier
+
   controller do
     def check_dependent(object)
       if object.items.count > 0 || object.collections.count > 0


### PR DESCRIPTION
Fixes #512 "Language filters have been changed and are now wrong".

Add in explicit calls to filter the admin interface by attributes that make sense, so the attributes that don't make sense aren't supplied as filter options.

To review: Nothing. The approach taken is the same as that in pull request #489 "Fix #488 language list is wrong".
