### PR TITLE
Feature/nabu 507

### DIFF
--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -24,6 +24,10 @@ class Language < ActiveRecord::Base
     "#{name} - #{code}"
   end
 
+  def language_archive_link
+    "http://www.language-archives.org/language/#{code}"
+  end
+
   has_many :countries_languages
   has_many :countries, :through => :countries_languages, :dependent => :destroy
   accepts_nested_attributes_for :countries_languages, :allow_destroy => true

--- a/app/views/collections/show.html.haml
+++ b/app/views/collections/show.html.haml
@@ -68,6 +68,7 @@
         %td
           - @collection.languages.each do |language|
             #{language.name_with_code}
+            = link_to 'See other information in this language', language.language_archive_link, class: 'button'
             %br
 
       %tr

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -83,6 +83,7 @@
         %td
           - @item.subject_languages.each do |language|
             = language.name_with_code
+            = link_to 'See other information in this language', language.language_archive_link, class: 'button'
             %br
 
       %tr
@@ -90,6 +91,7 @@
         %td
           - @item.content_languages.each do |language|
             = language.name_with_code
+            = link_to 'See other information in this language', language.language_archive_link, class: 'button'
             %br
 
       %tr
@@ -177,6 +179,7 @@
         %td
           - @item.collection.languages.each do |language|
             = language.name_with_code
+            = link_to 'See other information in this language', language.language_archive_link, class: 'button'
             %br
     - if can? :manage, @item
       %div.separated-message

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -176,7 +176,7 @@
         %th Languages
         %td
           - @item.collection.languages.each do |language|
-            = language.name
+            = language.name_with_code
             %br
     - if can? :manage, @item
       %div.separated-message


### PR DESCRIPTION
Fixes #507 "Add a new button to show other items of same language".

To review:

* Are there any security issues with `Language#language_archive_link`? As languages are admin-controlled, I think it's safe, but I'd like to check.
* There's no special reason `Language#name` was used in `app/views/items/show.html.haml`, was there?
