### PR TITLE
Fix #377 CSV export from advanced search

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -51,7 +51,7 @@ class CollectionsController < ApplicationController
 
   def advanced_search
     @page_title = 'Nabu - Advanced Search Collections'
-    do_search
+    @search = build_advanced_search(params)
   end
 
   def new
@@ -152,7 +152,7 @@ class CollectionsController < ApplicationController
     @page_title = 'Nabu - Collections Bulk Update'
     @collection = Collection.new
 
-    do_search
+    @search = build_advanced_search(params)
   end
 
 
@@ -194,7 +194,7 @@ class CollectionsController < ApplicationController
     if invalid_record
       @page_title = 'Nabu - Collections Bulk Update'
       @collection = Collection.new
-      do_search
+      @search = build_advanced_search(params)
       render :action => 'bulk_edit'
     else
       flash[:notice] = 'Collections were successfully updated.'
@@ -306,10 +306,8 @@ class CollectionsController < ApplicationController
     end
   end
 
-  def do_search
-    @fields = Sunspot::Setup.for(Collection).fields
-    @text_fields = Sunspot::Setup.for(Collection).all_text_fields
-    @search = Collection.solr_search do
+  def build_advanced_search(params)
+    Collection.solr_search do
       # Full text search
       Sunspot::Setup.for(Collection).all_text_fields.each do |field|
         next if params[field.name].blank?

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -42,7 +42,7 @@ class CollectionsController < ApplicationController
       format.html
       if can? :search_csv, Collection
         format.csv do
-          fields = [:identifier, :title, :description, :collector_name, :operator_name, :university_name, :csv_languages, :csv_countries, :region, :north_limit, :south_limit, :west_limit, :east_limit, :field_of_research_name, :grant_identifier, :funding_body_names, :access_condition_name, :access_narrative]
+          fields = [:identifier, :title, :description, :collector_name, :operator_name, :university_name, :csv_languages, :csv_countries, :region, :north_limit, :south_limit, :west_limit, :east_limit, :field_of_research_name, :csv_full_grant_identifiers, :funding_body_names, :access_condition_name, :access_narrative]
           send_data @search.results.to_csv({:headers => fields, :only => fields}, :col_sep => ','), :type => "text/csv; charset=utf-8; header=present"
         end
       end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -52,6 +52,15 @@ class CollectionsController < ApplicationController
   def advanced_search
     @page_title = 'Nabu - Advanced Search Collections'
     @search = build_advanced_search(params)
+    respond_to do |format|
+      format.html
+      if can? :search_csv, Collection
+        format.csv do
+          fields = [:identifier, :title, :description, :collector_name, :operator_name, :university_name, :csv_languages, :csv_countries, :region, :north_limit, :south_limit, :west_limit, :east_limit, :field_of_research_name, :csv_full_grant_identifiers, :funding_body_names, :access_condition_name, :access_narrative]
+          send_data @search.results.to_csv({:headers => fields, :only => fields}, :col_sep => ','), :type => "text/csv; charset=utf-8; header=present"
+        end
+      end
+    end
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,22 +28,7 @@ class ItemsController < ApplicationController
       format.html
       if can? :search_csv, Item
         format.csv do
-          filename = "nabu_items_#{Date.today.to_s}.csv"
-          self.response.headers['Content-Type'] = 'text/csv; charset=utf-8; header=present'
-          self.response.headers['Content-Disposition'] = "attachment; filename=#{filename}"
-          self.response.headers['Last-Modified'] = Time.now.ctime.to_s
-
-          # use enumerator to customise streaming the response
-          self.response_body = Enumerator.new do |output|
-            # wrap the IO output so that CSV pushes writes directly into it
-            csv = CSV.new(output, CSV_OPTIONS)
-            @search.results.each{|r| csv << INCLUDED_CSV_FIELDS.map{|f| r.public_send(f)}}
-            # if the user requested all results, iterate over the remaining pages
-            while params[:export_all] && @search.results.next_page
-              @search = build_solr_search(params.merge(page: @search.results.next_page))
-              @search.results.each{|r| csv << INCLUDED_CSV_FIELDS.map{|f| r.public_send(f)}}
-            end
-          end
+          stream_csv(:basic)
         end
       end
     end
@@ -52,27 +37,11 @@ class ItemsController < ApplicationController
   def advanced_search
     @page_title = 'Nabu - Advanced Item Search'
     @search = build_advanced_search(params)
-    # The following is identical to #search, except for the call to build_advanced_search
     respond_to do |format|
       format.html
       if can? :search_csv, Item
         format.csv do
-          filename = "nabu_items_#{Date.today.to_s}.csv"
-          self.response.headers['Content-Type'] = 'text/csv; charset=utf-8; header=present'
-          self.response.headers['Content-Disposition'] = "attachment; filename=#{filename}"
-          self.response.headers['Last-Modified'] = Time.now.ctime.to_s
-
-          # use enumerator to customise streaming the response
-          self.response_body = Enumerator.new do |output|
-            # wrap the IO output so that CSV pushes writes directly into it
-            csv = CSV.new(output, CSV_OPTIONS)
-            @search.results.each{|r| csv << INCLUDED_CSV_FIELDS.map{|f| r.public_send(f)}}
-            # if the user requested all results, iterate over the remaining pages
-            while params[:export_all] && @search.results.next_page
-              @search = build_advanced_search(params.merge(page: @search.results.next_page))
-              @search.results.each{|r| csv << INCLUDED_CSV_FIELDS.map{|f| r.public_send(f)}}
-            end
-          end
+          stream_csv(:advanced)
         end
       end
     end
@@ -409,4 +378,26 @@ class ItemsController < ApplicationController
     end
   end
 
+  def stream_csv(search_type)
+    filename = "nabu_items_#{Date.today.to_s}.csv"
+    self.response.headers['Content-Type'] = 'text/csv; charset=utf-8; header=present'
+    self.response.headers['Content-Disposition'] = "attachment; filename=#{filename}"
+    self.response.headers['Last-Modified'] = Time.now.ctime.to_s
+
+    # use enumerator to customise streaming the response
+    self.response_body = Enumerator.new do |output|
+      # wrap the IO output so that CSV pushes writes directly into it
+      csv = CSV.new(output, CSV_OPTIONS)
+      @search.results.each{|r| csv << INCLUDED_CSV_FIELDS.map{|f| r.public_send(f)}}
+      # if the user requested all results, iterate over the remaining pages
+      while params[:export_all] && @search.results.next_page
+        @search = if search_type == :basic
+                    build_solr_search(params.merge(page: @search.results.next_page))
+                  else
+                    build_advanced_search(params.merge(page: @search.results.next_page))
+                  end
+        @search.results.each{|r| csv << INCLUDED_CSV_FIELDS.map{|f| r.public_send(f)}}
+      end
+    end
+  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,6 +7,7 @@ class ItemsController < ApplicationController
   authorize_resource :only => [:advanced_search, :bulk_update, :bulk_edit, :new_report, :send_report, :report_sent]
 
   INCLUDED_CSV_FIELDS = [:full_identifier, :title, :external, :description, :url, :collector_sortname, :operator_name, :csv_item_agents,
+                         :csv_filenames, :csv_mimetypes, :csv_fps_values, :csv_samplerates, :csv_channel_counts,
                          :university_name, :language, :dialect, :csv_subject_languages, :csv_content_languages, :csv_countries, :region, :csv_data_categories,
                          :discourse_type_name, :originated_on, :originated_on_narrative, :north_limit, :south_limit, :west_limit, :east_limit, :access_condition_name,
                          :access_narrative]

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -51,7 +51,7 @@ class ItemsController < ApplicationController
 
   def advanced_search
     @page_title = 'Nabu - Advanced Item Search'
-    do_search
+    @search = build_advanced_search(params)
   end
 
   def new
@@ -164,7 +164,7 @@ class ItemsController < ApplicationController
     @item.collection = Collection.new
     @page_title = 'Nabu - Items Bulk Update'
 
-    do_search
+    @search = build_advanced_search(params)
   end
 
 
@@ -210,7 +210,7 @@ class ItemsController < ApplicationController
     end
 
     if invalid_record
-      do_search
+      @search = build_advanced_search(params)
       @page_title = 'Nabu - Items Bulk Update'
       render :action => 'bulk_edit'
     else
@@ -277,10 +277,8 @@ class ItemsController < ApplicationController
     end
   end
 
-  def do_search
-    @fields = Sunspot::Setup.for(Item).fields
-    @text_fields = Sunspot::Setup.for(Item).all_text_fields
-    @search = Item.solr_search do
+  def build_advanced_search(params)
+    Item.solr_search do
       # Full text search
       Sunspot::Setup.for(Item).all_text_fields.each do |field|
         next if params[field.name].blank?

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -282,6 +282,10 @@ class Collection < ActiveRecord::Base
     languages.map(&:name).join(';')
   end
 
+  def csv_full_grant_identifiers
+    grants.map(&method(:full_grant_identifier)).join(';')
+  end
+
   def oai_language
     languages.map(&:name).join(', ')
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -423,6 +423,26 @@ class Item < ActiveRecord::Base
     result
   end
 
+  def csv_filenames
+    essences.map(&:filename).join(';')
+  end
+
+  def csv_mimetypes
+    essences.map(&:mimetype).join(';')
+  end
+
+  def csv_fps_values
+    essences.map(&:fps).join(';')
+  end
+
+  def csv_samplerates
+    essences.map(&:samplerate).join(';')
+  end
+
+  def csv_channel_counts
+    essences.map(&:channels).join(';')
+  end
+
   # OAI-MPH mappings for OLAC
   # If we need to later on we can generate the XML directly
   # TODO

--- a/app/views/collections/advanced_search.html.haml
+++ b/app/views/collections/advanced_search.html.haml
@@ -211,3 +211,7 @@
 
   .clear
 
+  %p
+    = link_to 'Export CSV (visible results)', advanced_search_collections_path(:format => :csv, :params => params) if can? :search_csv, Collection
+  %p
+    = link_to 'Export CSV (all results)', advanced_search_collections_path(:format => :csv, :params => params.merge(:per_page => @search.total, :page => 1)) if can? :search_csv, Collection

--- a/app/views/items/advanced_search.html.haml
+++ b/app/views/items/advanced_search.html.haml
@@ -301,3 +301,8 @@
     = submit_tag 'Clear', :name => :clear
 
   .clear
+
+  %p
+    = link_to 'Export CSV (visible results)', advanced_search_items_path(:format => :csv, :params => params) if can? :search_csv, Item
+  %p
+    = link_to 'Export CSV (all results)', advanced_search_items_path(:format => :csv, :params => params.merge(:per_page => 500, :page => 1, :export_all => true)) if can? :search_csv, Item

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -82,7 +82,6 @@ ActiveRecord::Schema.define(:version => 20151125060951) do
     t.boolean  "private"
     t.string   "tape_location"
     t.boolean  "deposit_form_received"
-    t.string   "grant_identifier"
     t.float    "north_limit"
     t.float    "south_limit"
     t.float    "west_limit"


### PR DESCRIPTION
Fixes #377 "CSV export from faceted search or advanced search".

Changes made in this commit:

* All relevant fields from Item are exported, as per Amanda's comment.
* Collections can actually export to CSV - previously, a bug meant they couldn't.
* CSV can be exported for both collection and item advanced search

This pull request doesn't do anything about collection advanced search offering search fields of funding body and grant identifier which don't work.
