### PR TITLE
Feature/nabu 535

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -554,7 +554,6 @@ Style/SpaceAfterColon:
 Style/SpaceAfterComma:
   Exclude:
     - 'Capfile'
-    - 'app/controllers/concerns/has_return_to_last_search.rb'
     - 'app/controllers/items_controller.rb'
     - 'app/controllers/oai_controller.rb'
     - 'app/models/collection.rb'

--- a/app/controllers/concerns/has_return_to_last_search.rb
+++ b/app/controllers/concerns/has_return_to_last_search.rb
@@ -23,6 +23,11 @@ module HasReturnToLastSearch
     Proc.new { |k, _v| %w(controller action).include?(k) }
   end
 
+  # People only want to download CSVs once. Don't keep it in the session.
+  def one_off_params
+    Proc.new { |k, _v| %w(format).include?(k) }
+  end
+
   def should_apply_session_params?
     # if we're coming to the same page (e.g. visiting basic search with saved basic search)...
     if session[:search_from] == params.select(&only_action_params)
@@ -42,7 +47,7 @@ module HasReturnToLastSearch
         session.delete(:search_params)
       else
         session[:search_from] = params.select(&only_action_params)
-        session[:search_params] = params.reject(&only_action_params)
+        session[:search_params] = params.reject(&only_action_params).reject(&one_off_params)
       end
     elsif should_apply_session_params?
       # transfer the flash over from the previous action (otherwise it is lost)

--- a/app/controllers/concerns/has_return_to_last_search.rb
+++ b/app/controllers/concerns/has_return_to_last_search.rb
@@ -20,7 +20,7 @@ module HasReturnToLastSearch
 
   # utility method to keep the multiple uses of this proc consistent w/ no typos
   def only_action_params
-    Proc.new {|k,v| %w(controller action).include?(k)}
+    Proc.new { |k, _v| %w(controller action).include?(k) }
   end
 
   def should_apply_session_params?


### PR DESCRIPTION
Fix #535 "Return to Results bug".

Basically, we're caching the fact they asked for a CSV, and assume they want to ask for CSVs in the future. That doesn't make sense.

To review:

* Theoretically, we ought to clear out existing session data for `[:search_params]`. Is that worthwhile?