### PR TITLE
Slow saving: Detect bad value for user_ids

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -143,6 +143,11 @@ class ItemsController < ApplicationController
   end
 
   def update
+    if params[:item] && params[:item][:user_ids] && params[:item][:user_ids] == "[]"
+      flash[:alert] = "Error in submitted value for View/Download access users"
+      redirect_to [@collection, @item]
+      return
+    end
     @num_files = @item.essences.length
     @files = @item.essences.page(params[:files_page]).per(params[:files_per_page])
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -143,7 +143,7 @@ class ItemsController < ApplicationController
   end
 
   def update
-    if params[:item] && params[:item][:user_ids] && params[:item][:user_ids] == "[]"
+    if params[:item] && params[:item][:user_ids].is_a?(String) && !params[:item][:user_ids].empty?
       flash[:alert] = "Error in submitted value for View/Download access users"
       redirect_to [@collection, @item]
       return


### PR DESCRIPTION
A stopgap measure for the error caused by having bad values for `user_ids`, as reported in the email "Nabu slow saving" and recorded in Rollbar under error items 201 and 136 ([example](https://rollbar.com/nabu/Nabu/items/201/occurrences/10864232930/)).

To get to the bottom of it, we'll need to find out how these bad values are being created.

To review:

* Does this code more or less make sense, at least for this very weird scenario?
