### PR TITLE
Issue #475 comment February 23: Use URI if DOI unavailable

### DIFF
--- a/app/models/essence.rb
+++ b/app/models/essence.rb
@@ -75,7 +75,11 @@ class Essence < ActiveRecord::Base
     cite += filename
     cite += ", "
     cite += "#{Date.today}."
-    cite += " DOI: #{doi}" if doi
+    if doi
+      cite += " DOI: #{doi}"
+    else
+      cite += " #{full_path}"
+    end
     cite
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -388,7 +388,11 @@ class Item < ActiveRecord::Base
         end
     end
     cite += " #{Date.today}."
-    cite += " DOI: #{doi}" if doi
+    if doi
+      cite += " DOI: #{doi}"
+    else
+      cite += " #{full_path}"
+    end
     cite
   end
 

--- a/spec/models/essence_spec.rb
+++ b/spec/models/essence_spec.rb
@@ -20,12 +20,26 @@
 require 'spec_helper'
 
 describe Essence do
-  let(:essence) { create(:sound_essence) }
+  let(:essence) { create(:sound_essence, doi: doi) }
 
   describe '#citation' do
-    it 'uses DOI' do
-      essence.should_receive(:doi) { '' }.twice
-      essence.citation
+    context 'DOI exists' do
+      let(:doi) { 'something' }
+
+      it 'uses DOI, not URI' do
+        essence.should_receive(:doi) { doi }.twice
+        essence.citation
+      end
+    end
+
+    context 'DOI nil' do
+      let(:doi) { nil }
+
+      it 'uses URI' do
+        essence.should_receive(:doi) { doi }.once
+        essence.should_receive(:full_path) { '' }
+        essence.citation
+      end
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -44,12 +44,26 @@
 require 'spec_helper'
 
 describe Item do
-  let(:item) { build(:item) }
+  let(:item) { build(:item, doi: doi) }
 
   describe '#citation' do
-    it 'uses DOI, not URI' do
-      item.should_receive(:doi) { '' }.twice
-      item.citation
+    context 'DOI exists' do
+      let(:doi) { 'something' }
+
+      it 'uses DOI, not URI' do
+        item.should_receive(:doi) { doi }.twice
+        item.citation
+      end
+    end
+
+    context 'DOI nil' do
+      let(:doi) { nil }
+
+      it 'uses URI' do
+        item.should_receive(:doi) { doi }.once
+        item.should_receive(:full_path) { '' }
+        item.citation
+      end
     end
   end
 end


### PR DESCRIPTION
From https://github.com/nabu-catalog/nabu/issues/475#issuecomment-187626444 

> It may be that this has been left out due to the likely addition of a doi, but that is some way off and should have happened incrementally, the doi replacing the url.

This uses the URL if the DOI is not available.

Simple enough to not need reviewing.