### PR TITLE
Performance: Avoid N + 1 on home page

### DIFF
--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -1,7 +1,8 @@
 class PageController < ApplicationController
   def home
     @page_title = "Nabu - Home"
-    @coordinates = Collection.where(:private => false).map(&:center_coordinate).compact
+    item_counts = Item.count(:group => :collection_id)
+    @coordinates = Collection.where(:private => false).map{|c| c.center_coordinate(item_counts)}.compact
     @content = render_to_string :partial => 'page/infowindow'
   end
 
@@ -29,7 +30,8 @@ class PageController < ApplicationController
     @comments_left = Item.where(:collector_id => current_user).map(&:comments).flatten
     @num_comments_left = @comments_left.count
 
-    @coordinates = @collections.map(&:center_coordinate).compact
+    item_counts = Item.count(:group => :collection_id)
+    @coordinates = @collections.map{|c| c.center_coordinate(item_counts)}.compact
     @north_limit = @coordinates.map{|c| c[:lat]}.max
     @south_limit = @coordinates.map{|c| c[:lat]}.min
     @east_limit  = @coordinates.map{|c| c[:lng]}.max

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -257,7 +257,7 @@ class Collection < ActiveRecord::Base
     (east_limit && east_limit != 0)
   end
 
-  def center_coordinate
+  def center_coordinate(item_counts)
     if has_coordinates
       if east_limit < west_limit
         long = 180 + (west_limit + east_limit) / 2
@@ -269,7 +269,7 @@ class Collection < ActiveRecord::Base
         :lng => long,
         :title => title,
         :id => identifier,
-        :items => items.count,
+        :items => item_counts[id],
       }
     end
   end


### PR DESCRIPTION
The New Relic page on Transactions says that PageController#home accounts for 41% of time taken. This is due to a N + 1 problem happening on the home page - what everybody visits, presumably including the bots.

This won't fix everything, but it was a very easy fix to make.