### PR TITLE
Fix #547 Rif-CS feed

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -320,7 +320,7 @@ class Collection < ActiveRecord::Base
                 xml.value full_path
               end
               xml.physical 'type' => 'postalAddress' do
-                xml.addressPart 'PARADISEC Sydney, Department of Linguistics, second floor Transient Building F12, Fisher Road, The University of Sydney, Camperdown Campus, NSW 2006, AUSTRALIA, Phone: +61 2 9351 2002', 'type' => 'text'
+                xml.addressPart 'PARADISEC Sydney Unit: Sydney Conservatorium of Music, Rm 3019, Building C41, The University of Sydney, NSW, 2006, Phone +61 2 9351 1279. PARADISEC Melbourne Unit: School of Languages and Linguistics, University of Melbourne, +61 2 8344 8952 | PARADISEC Canberra Unit: College of Asia and the Pacific, The Australian National University, +61 2 6125 6115', 'type' => 'text'
               end
             end
           end
@@ -422,9 +422,6 @@ class Collection < ActiveRecord::Base
             xml.address do
               xml.electronic 'type' => 'url' do
                 xml.value collector.full_path
-              end
-              xml.physical 'type' => 'postalAddress' do
-                xml.addressPart collector.name + ' c/o PARADISEC, Department of Linguistics, The University of Sydney', 'type' => 'text'
               end
             end
           end


### PR DESCRIPTION
`' c/o PARADISEC, Department of Linguistics, The University of Sydney'` has been deleted, in addition to the initially requested change.