### PR TITLE
Fix #545

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -365,7 +365,6 @@ Style/IndentationConsistency:
 # Configuration parameters: Width.
 Style/IndentationWidth:
   Exclude:
-    - 'app/controllers/application_controller.rb'
     - 'app/helpers/application_helper.rb'
     - 'app/models/collection.rb'
     - 'app/models/item.rb'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,11 @@ class ApplicationController < ActionController::Base
   end
 
   rescue_from CanCan::AccessDenied do |exception|
-    redirect_to root_url, :alert => exception.message
+    if current_user
+      redirect_to root_url, :alert => exception.message
+    else
+      redirect_to new_user_session_path, :alert => exception.message
+    end
   end
 
   def set_timezone

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,7 @@ class ApplicationController < ActionController::Base
     if current_user
       redirect_to root_url, :alert => exception.message
     else
+      session["user_return_to"] = request.fullpath
       redirect_to new_user_session_path, :alert => exception.message
     end
   end
@@ -37,7 +38,7 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(resource)
-   dashboard_path
+    stored_location_for(resource) || dashboard_path
   end
 
   # used by collections_controller and items_controller for creating Collectors and Agents

--- a/spec/controllers/essences_controller_spec.rb
+++ b/spec/controllers/essences_controller_spec.rb
@@ -18,9 +18,9 @@ describe EssencesController, type: :controller do
 
   context 'when not logged in' do
     context 'when viewing an essence' do
-      it 'should redirect to the home page with error' do
+      it 'should redirect to the sign in page with error' do
         get :show, params
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(new_user_session_path)
         expect(flash[:alert]).to_not be_nil
       end
     end

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -24,9 +24,9 @@ describe ItemsController, type: :controller do
   context 'when not logged in' do
     context 'when viewing' do
       context 'a private item' do
-        it 'should redirect to the home page with error' do
+        it 'should redirect to the sign in page with error' do
           get :show, params.merge(id: private_item.identifier)
-          expect(response).to redirect_to(root_path)
+          expect(response).to redirect_to(new_user_session_path)
           expect(flash[:alert]).to_not be_nil
         end
       end


### PR DESCRIPTION
Fix #545 "When page requires login, it should redirect back to page after successful login".

This redirects anonymous users to sign in when they're not authorized to see something, and redirects them back to the page when they sign in.

Logged in users who merely lack authorization to see a particular page just get sent to the root path as before.

To review:

* There wasn't any existing functionality to redirect users to the sign in page, was there?
