### PR TITLE
Issue #561 diagnosis: Allow import_metadata to fail in archive:update…

### DIFF
--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -202,7 +202,13 @@ namespace :archive do
         end
 
         # extract media metadata from file
-        import_metadata(directory, file, item, extension, force_update)
+        begin
+          import_metadata(directory, file, item, extension, force_update)
+        rescue => e
+          puts "WARNING: file #{file} skipped - error importing metadata [#{e.message}]" if verbose
+          puts " >> #{e.backtrace}"
+          next
+        end
       end
     end
     puts "===" if verbose


### PR DESCRIPTION
…_files task

I'm currently working on #561 (Files failing but archive message says success).

I try running `bundle exec rake archive:update_files` on production, and I get the following error:

    Inspecting file AS2-006a-3728.jpg...
    rake aborted!
    Magick::ImageMagickError: Not a JPEG file: starts with 0x00 0x00 `/srv/catalog/AS2/006a/AS2-006a-3728.jpg' @ error/jpeg.c/JPEGErrorHandler/316
    /srv/www/nabu/shared/bundle/ruby/1.9.1/gems/rmagick-2.15.2/lib/rmagick_internal.rb:1616:in `read'
    /srv/www/nabu/shared/bundle/ruby/1.9.1/gems/rmagick-2.15.2/lib/rmagick_internal.rb:1616:in `block in initialize'
    /srv/www/nabu/shared/bundle/ruby/1.9.1/gems/rmagick-2.15.2/lib/rmagick_internal.rb:1615:in `each'
    /srv/www/nabu/shared/bundle/ruby/1.9.1/gems/rmagick-2.15.2/lib/rmagick_internal.rb:1615:in `initialize'
    /srv/www/nabu/releases/20160317075432/app/services/image_transformer_service.rb:12:in `new'
    /srv/www/nabu/releases/20160317075432/app/services/image_transformer_service.rb:12:in `initialize'
    /srv/www/nabu/releases/20160317075432/lib/tasks/archive.rake:414:in `new'
    /srv/www/nabu/releases/20160317075432/lib/tasks/archive.rake:414:in `generate_derived_files'
    /srv/www/nabu/releases/20160317075432/lib/tasks/archive.rake:379:in `import_metadata'
    /srv/www/nabu/releases/20160317075432/lib/tasks/archive.rake:205:in `block (4 levels) in <top (required)>'
    /srv/www/nabu/releases/20160317075432/lib/tasks/archive.rake:187:in `each'
    /srv/www/nabu/releases/20160317075432/lib/tasks/archive.rake:187:in `block (3 levels) in <top (required)>'
    /srv/www/nabu/releases/20160317075432/lib/tasks/archive.rake:182:in `each'
    /srv/www/nabu/releases/20160317075432/lib/tasks/archive.rake:182:in `block (2 levels) in <top (required)>'
    Tasks: TOP => archive:update_files
    (See full trace by running task with --trace)

The file itself seems dodgy, rather than it being an Magick bug.

To review:

* Was there any particular reason this task didn't have error handling before?