### PR TITLE
Reduce crashing

### DIFF
--- a/app/services/batch_image_transformer_service.rb
+++ b/app/services/batch_image_transformer_service.rb
@@ -23,7 +23,7 @@ class BatchImageTransformerService
       next unless File.file?(image_file.path)
       item = image_file.item
       file = image_file.path
-      extension = 'jpg'
+      extension = File.extname(file)
       begin
         media = Nabu::Media.new image_file.path
         image_transformer = ImageTransformerService.new(media, file, item, image_file, extension)

--- a/app/services/image_transformer_service.rb
+++ b/app/services/image_transformer_service.rb
@@ -44,6 +44,7 @@ class ImageTransformerService
       @essence.derived_files_generated = true
       @essence.save
     end
+    @image_list.each(&:destroy!)
   end
 
   private
@@ -85,6 +86,7 @@ class ImageTransformerService
 
         outfile = image.resize_to_fit(size, size)
         outfile.write(file_path) { self.quality = 50 }
+        outfile.destroy!
       end
     end
   end

--- a/app/services/image_transformer_service.rb
+++ b/app/services/image_transformer_service.rb
@@ -7,19 +7,18 @@ class ImageTransformerService
 
   def initialize(media, file, item, essence, extension, thumbnail_sizes = [144])
     @mimetype = media.mimetype
-    if @mimetype.start_with?('image')
-      @file = file
-      @image_list = ImageList.new(@file)
-      @multipart = (@image_list.length > 1)
-      @item = item
-      @extension = extension
-      @essence = essence
-      @thumbnail_sizes = thumbnail_sizes
-    end
+    @file = file
+    @item = item
+    @extension = extension
+    @essence = essence
+    @thumbnail_sizes = thumbnail_sizes
+    # Defer evaluating @image_list and @multipart until `perform_conversions`, the only public method available, is called
   end
 
   def perform_conversions
     return unless @mimetype.start_with?('image')
+    @image_list = ImageList.new(@file)
+    @multipart = (@image_list.length > 1)
 
     generated_essences = []
 
@@ -46,6 +45,8 @@ class ImageTransformerService
       @essence.save
     end
   end
+
+  private
 
   # converts the file into the specified format and returns its new path (or nil if it already existed)
   def convert_to(format, extension, quality = 50)
@@ -87,8 +88,6 @@ class ImageTransformerService
       end
     end
   end
-
-  private
 
   #build an appropriate new file path based on pages, thumbnails and format where provided
   def create_file_path(extension, format, page_number = nil, is_thumbnail = false)

--- a/app/services/image_transformer_service.rb
+++ b/app/services/image_transformer_service.rb
@@ -103,7 +103,7 @@ class ImageTransformerService
       new_suffix = "-page#{page_number}#{new_suffix}"
     end
 
-    @file.sub(".#{extension}", new_suffix)
+    @file.sub(extension, new_suffix)
   end
 
   def convert_tif_to_jpg(generated_essences)

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -418,6 +418,6 @@ namespace :archive do
 
   # this method tries to avoid regenerating any files that already exist
   def generate_derived_files(full_file_path, item, essence, extension, media)
-    ImageTransformerService.new(media, full_file_path, item, essence, extension).perform_conversions
+    ImageTransformerService.new(media, full_file_path, item, essence, ".#{extension}").perform_conversions
   end
 end


### PR DESCRIPTION
Discussed last week. For work on #561 .

The branch does the following:

* Destroys magick objects after they've been used, to reduce the change of crashes occurring.
* When determining the file name of generated files, remove the real original extension, rather than a hard-wired extension of `jpg`.

To review:

* Would you be able to run this code on your computer to check it doesn't raise an exception due to any stupid bugs?
* With regards to the second change, I don't understand how this code worked in the first place.

Doing `find . -name "*JPG*" | grep -i thumb` suggests there's no thumbnails with a `.JPG` extension, which is good. But doing `essence = Essence.where(derived_files_generated: true).where("BINARY filename like ?", "%JPG%").first` gives the essence for SAW3-006-img01.JPG, which has `SAW3-006-img01-thumb-PDSC_ADMIN.jpg` as a thumbnail.

* Are you happy with the coding style - moving the instance variable assignment into a non-initialization method?
