### PR TITLE
Issue #436 related improvements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 1.9
+  TargetRubyVersion: 2.1

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,7 +11,7 @@ Metrics/AbcSize:
 
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 421
+  Max: 446
 
 Metrics/CyclomaticComplexity:
   Max: 62
@@ -47,6 +47,11 @@ Performance/Detect:
 Performance/RedundantMatch:
   Exclude:
     - 'app/models/item.rb'
+
+# Cop supports --auto-correct.
+Performance/RedundantMerge:
+  Exclude:
+    - 'config/initializers/rollbar.rb'
 
 # Cop supports --auto-correct.
 Performance/StringReplacement:
@@ -99,6 +104,7 @@ Style/BarePercentLiterals:
 # IgnoredMethods: lambda, proc, it
 Style/BlockDelimiters:
   Exclude:
+    - 'config/initializers/rollbar.rb'
     - 'spec/controllers/items_controller_spec.rb'
 
 # Cop supports --auto-correct.
@@ -191,6 +197,7 @@ Style/ConditionalAssignment:
     - 'app/controllers/versions_controller.rb'
     - 'app/models/collection.rb'
     - 'app/models/comment.rb'
+    - 'app/models/essence.rb'
     - 'app/models/item.rb'
     - 'app/services/item_destruction_service.rb'
     - 'lib/exsite9.rb'
@@ -221,7 +228,6 @@ Style/EmptyLines:
     - 'app/controllers/collections_controller.rb'
     - 'app/controllers/items_controller.rb'
     - 'app/models/ability.rb'
-    - 'app/models/comment.rb'
     - 'app/models/item.rb'
     - 'app/oai/collection_provider.rb'
     - 'config/initializers/active_admin.rb'
@@ -256,7 +262,6 @@ Style/EmptyLinesAroundBlockBody:
 # SupportedStyles: empty_lines, no_empty_lines
 Style/EmptyLinesAroundClassBody:
   Exclude:
-    - 'app/controllers/items_controller.rb'
     - 'app/controllers/repository_controller.rb'
     - 'app/models/collection.rb'
     - 'app/models/comment.rb'
@@ -282,7 +287,6 @@ Style/EmptyLinesAroundMethodBody:
 # SupportedStyles: empty_lines, no_empty_lines
 Style/EmptyLinesAroundModuleBody:
   Exclude:
-    - 'app/helpers/application_helper.rb'
     - 'lib/nabu_spreadsheet.rb'
     - 'spec/support/select2.rb'
 
@@ -475,6 +479,7 @@ Style/PercentLiteralDelimiters:
     - 'app/oai/collection_provider.rb'
     - 'app/oai/item_provider.rb'
     - 'config/environments/production.rb'
+    - 'config/initializers/rollbar.rb'
     - 'lib/media.rb'
 
 # Cop supports --auto-correct.
@@ -482,6 +487,7 @@ Style/PerlBackrefs:
   Exclude:
     - 'app/controllers/collections_controller.rb'
     - 'app/controllers/items_controller.rb'
+    - 'config/initializers/rollbar.rb'
 
 # Configuration parameters: NamePrefix, NamePrefixBlacklist, NameWhitelist.
 # NamePrefix: is_, has_, have_

--- a/Gemfile
+++ b/Gemfile
@@ -31,8 +31,7 @@ gem 'meta_search', '>= 1.1.0.pre'
 
 # Authentications
 gem 'devise', '2.2.3'
-# 1.13.x requires Ruby 2.0
-gem 'cancancan', '~> 1.12.0'
+gem 'cancancan', '~> 1.13.1'
 
 # Database improvements
 gem 'squeel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
       sass (>= 3.2.0)
       thor
     builder (3.0.4)
-    cancancan (1.12.0)
+    cancancan (1.13.1)
     capistrano (2.14.2)
       highline
       net-scp (>= 1.0.0)
@@ -399,7 +399,7 @@ DEPENDENCIES
   annotate
   better_errors
   binding_of_caller
-  cancancan (~> 1.12.0)
+  cancancan (~> 1.13.1)
   capistrano
   capistrano-rbenv
   capistrano-unicorn


### PR DESCRIPTION
Improvements now that we're using Ruby 2.1.9.

To review:

* Updating cancancan shouldn't break anything, because we've got unit tests that test that cancancan does what it does, right? It's to the same version as in your Rails 4 branch.
