### PR TITLE
Change individual page filenames

### DIFF
--- a/app/services/batch_update_individual_page_file_service.rb
+++ b/app/services/batch_update_individual_page_file_service.rb
@@ -1,0 +1,48 @@
+# Update the individual page files, to no longer have dashes
+class BatchUpdateIndividualPageFileService
+  def self.run(dry_run)
+    batch_update_individual_page_file_service = new(dry_run)
+    batch_update_individual_page_file_service.run
+  end
+
+  def initialize(dry_run)
+    @dry_run = dry_run
+  end
+
+  def run
+    essences = Essence.where("filename like '%-page%'")
+    essences.find_each(&method(:update_individual_page_file))
+  end
+
+  def update_individual_page_file(essence)
+    old_path = essence.path
+    unless essence.filename.index('-page') == essence.filename.rindex('-page')
+      puts "#{essence.filename} has multiple '-page's in it - skipping"
+      return
+    end
+
+    essence.filename = essence.filename.gsub('-page', 'page')
+    new_path = essence.path
+
+    unless File.exist?(old_path)
+      puts "Can't find original file #{old_path} - skipping"
+      return
+    end
+
+    if File.exist?(new_path)
+      puts "File #{new_path} already exists - skipping"
+      return
+    end
+
+    unless essence.valid?
+      puts "#{essence.filename} not valid - skipping"
+      return
+    end
+
+    unless @dry_run
+      FileUtils.mv(old_path, new_path)
+      essence.save!
+    end
+    puts "SUCCESS: #{old_path} moved to #{new_path}"
+  end
+end

--- a/app/services/image_transformer_service.rb
+++ b/app/services/image_transformer_service.rb
@@ -100,7 +100,7 @@ class ImageTransformerService
     end
 
     if @multipart && page_number.present?
-      new_suffix = "-page#{page_number}#{new_suffix}"
+      new_suffix = "page#{page_number}#{new_suffix}"
     end
 
     @file.sub(extension, new_suffix)

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -333,6 +333,12 @@ namespace :archive do
     BatchTranscodeEssenceFileService.run(batch_size)
   end
 
+  desc "Update filenames of individual pages generated from tif files"
+  task :update_individual_page_files => :environment do
+    dry_run = ENV['DRY_RUN'] ? true : false
+    BatchUpdateIndividualPageFileService.run(dry_run)
+  end
+
   # HELPERS
 
   def directories(path)


### PR DESCRIPTION
Change from generating files of the form `"RCSB1-ORIYA-LETTER-page1.jpg"` to the form `"RCSB1-ORIYA-LETTERpage1.jpg"`.

Also create a (hopefully one-off, never to be used again, delete after running) rake task to change existing filenames.

To review: Just check that I haven't overlooked anything.