### PR TITLE
Issue 561: Fix import process

### DIFF
--- a/app/models/essence.rb
+++ b/app/models/essence.rb
@@ -2,19 +2,20 @@
 #
 # Table name: essences
 #
-#  id         :integer          not null, primary key
-#  item_id    :integer
-#  filename   :string(255)
-#  mimetype   :string(255)
-#  bitrate    :integer
-#  samplerate :integer
-#  size       :integer
-#  duration   :float
-#  channels   :integer
-#  fps        :integer
-#  created_at :datetime
-#  updated_at :datetime
-#  doi        :string(255)
+#  id                      :integer          not null, primary key
+#  item_id                 :integer
+#  filename                :string(255)
+#  mimetype                :string(255)
+#  bitrate                 :integer
+#  samplerate              :integer
+#  size                    :integer
+#  duration                :float
+#  channels                :integer
+#  fps                     :integer
+#  created_at              :datetime
+#  updated_at              :datetime
+#  doi                     :string(255)
+#  derived_files_generated :boolean
 #
 
 class Essence < ActiveRecord::Base

--- a/app/models/essence.rb
+++ b/app/models/essence.rb
@@ -35,7 +35,8 @@ class Essence < ActiveRecord::Base
   validates :channels, :numericality => {:greater_than => 0, :allow_nil => true}
   validates :fps, :numericality => {:only_integer => true, :greater_than => 0, :allow_nil => true}
 
-  attr_accessible :item, :item_id, :filename, :mimetype, :bitrate, :samplerate, :size, :duration, :channels, :fps
+  # No need for doi to be attr_accessible
+  attr_accessible :item, :item_id, :filename, :mimetype, :bitrate, :samplerate, :size, :duration, :channels, :fps, :derived_files_generated
 
   def type
     types = mimetype.split("/",2)

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -450,21 +450,21 @@ namespace :archive do
       return
     end
 
-    unless essence.valid?
+    case
+    when !essence.valid?
       # Nabu Import messages 5.
       # Action: Move to rejected folder.
       puts "ERROR: invalid metadata for #{file} of type #{extension} - skipping"
       essence.errors.each { |field, msg| puts "#{field}: #{msg}" }
-      return
-    end
-    if essence.new_record? || (essence.changed? && force_update)
+    when essence.new_record? || (essence.changed? && force_update)
       essence.save!
       # Nabu Import Messages 2.
       puts "SUCCESS: file #{file} metadata imported into Nabu"
-    end
-    if essence.changed? && !force_update
+    when essence.changed?
       puts "WARNING: file #{file} metadata is different to DB - use 'FORCE=true archive:update_file' to update"
       puts essence.changes.inspect
+    else
+      # essence already exists, and is unchanged - don't do anything or log anything.
     end
   end
 

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -98,14 +98,6 @@ namespace :archive do
         # Action: Leave as-is.
         next unless File.file? "#{upload_directory}/#{file}"
 
-        # Nabu Import Messages 8.
-        # Action: Move to rejected folder.
-        # skip files of size 0 bytes
-        unless File.size?("#{upload_directory}/#{file}")
-          puts "WARNING: file #{file} skipped, since it is empty" if verbose
-          next
-        end
-
         # Nabu Import Messages 9.
         # Action: Leave as-is.
         # skip files that can't be read
@@ -118,6 +110,14 @@ namespace :archive do
         # Skip files that are currently uploading
         last_updated = File.stat("#{upload_directory}/#{file}").mtime
         if (Time.now - last_updated) < 60*10
+          next
+        end
+
+        # Nabu Import Messages 8.
+        # Action: Move to rejected folder.
+        # skip files of size 0 bytes
+        unless File.size?("#{upload_directory}/#{file}")
+          puts "WARNING: file #{file} skipped, since it is empty" if verbose
           next
         end
 

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -96,7 +96,9 @@ namespace :archive do
       # "#{collection_id}-#{item_id}-xxx.xxx"
       dir_contents.each do |file|
         # Action: Leave as-is.
-        next unless File.file? "#{upload_directory}/#{file}"
+        unless File.file? "#{upload_directory}/#{file}"
+          next
+        end
 
         # Nabu Import Messages 9.
         # Action: Leave as-is.
@@ -123,7 +125,9 @@ namespace :archive do
 
         # Action: Move to rejected folder.
         basename, extension, coll_id, item_id, collection, item = parse_file_name(file)
-        next unless (collection && item)
+        unless collection && item
+          next
+        end
 
         # Uncommon errors 1.
         # Action: Move to rejected folder.

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -139,29 +139,6 @@ namespace :archive do
 
         puts '---------------------------------------------------------------'
 
-        # Uncommon errors 2.
-        # Action: Leave as-is.
-        # make sure the archive directory for the collection and item exists
-        # and move the file there
-        begin
-          destination_path = Nabu::Application.config.archive_directory + "#{coll_id}/#{item_id}/"
-          FileUtils.mkdir_p(destination_path)
-        rescue
-          puts "WARNING: file #{file} skipped - not able to create directory #{destination_path}" if verbose
-          next
-        end
-
-        # Uncommon errors 3.
-        # Action: Leave as-is.
-        begin
-          FileUtils.cp(upload_directory + file, destination_path + file)
-        rescue
-          puts "WARNING: file #{file} skipped - not able to read it or write to #{destination_path + file}" if verbose
-          next
-        end
-
-        puts "INFO: file #{file} copied into archive at #{destination_path}"
-
         # move old style CAT and df files to the new naming scheme
         if basename.split('-').last == "CAT" || basename.split('-').last == "df"
           FileUtils.mv(destination_path + file, destination_path + "/" + basename + "-PDSC_ADMIN." + extension)
@@ -187,6 +164,29 @@ namespace :archive do
             next
           end
         end
+
+        # Uncommon errors 2.
+        # Action: Leave as-is.
+        # make sure the archive directory for the collection and item exists
+        # and move the file there
+        begin
+          destination_path = Nabu::Application.config.archive_directory + "#{coll_id}/#{item_id}/"
+          FileUtils.mkdir_p(destination_path)
+        rescue
+          puts "WARNING: file #{file} skipped - not able to create directory #{destination_path}" if verbose
+          next
+        end
+
+        # Uncommon errors 3.
+        # Action: Leave as-is.
+        begin
+          FileUtils.cp(upload_directory + file, destination_path + file)
+        rescue
+          puts "WARNING: file #{file} skipped - not able to read it or write to #{destination_path + file}" if verbose
+          next
+        end
+
+        puts "INFO: file #{file} copied into archive at #{destination_path}"
 
         # if everything went well, remove file from original directory
         FileUtils.rm(upload_directory + file)

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -167,11 +167,13 @@ namespace :archive do
           FileUtils.mv(destination_path + file, destination_path + "/" + basename + "-PDSC_ADMIN." + extension)
         end
 
+        is_non_admin_file = basename.split('-').last != "PDSC_ADMIN"
+
         # Action: If it's PDSC_ADMIN, move the file
         # Action: If it fails to import, move to rejected.
         # files of the pattern "#{collection_id}-#{item_id}-xxx-PDSC_ADMIN.xxx"
         # will be copied, but not added to the list of imported files in Nabu.
-        if basename.split('-').last != "PDSC_ADMIN"
+        if is_non_admin_file
           # extract media metadata from file
           puts "Inspecting file #{file}..."
           begin

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -95,6 +95,11 @@ namespace :archive do
       # by matching the pattern
       # "#{collection_id}-#{item_id}-xxx.xxx"
       dir_contents.each do |file|
+        # To move to the archive, have success true
+        # To move to rejected, have success false
+        # To leave alone, skip an iteration of this loop with next
+        success = true
+
         # Action: Leave as-is.
         unless File.file? "#{upload_directory}/#{file}"
           next

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -165,6 +165,9 @@ namespace :archive do
         # move old style CAT and df files to the new naming scheme
         if basename.split('-').last == "CAT" || basename.split('-').last == "df"
           FileUtils.mv(destination_path + file, destination_path + "/" + basename + "-PDSC_ADMIN." + extension)
+
+          file = basename + "-PDSC_ADMIN." + extension
+          basename, _extension, _coll_id, _item_id, _collection, _item = parse_file_name(file)
         end
 
         is_non_admin_file = basename.split('-').last != "PDSC_ADMIN"

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -193,11 +193,11 @@ namespace :archive do
             puts "WARNING: file #{file} skipped - not able to read it or write to #{destination_path + file}" if verbose
             next
           end
+
+          puts "INFO: file #{file} copied into archive at #{destination_path}"
         else
           # TODO: copy to the rejected place
         end
-
-        puts "INFO: file #{file} copied into archive at #{destination_path}"
 
         # if everything went well, remove file from original directory
         FileUtils.rm(upload_directory + file)

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -146,8 +146,12 @@ namespace :archive do
 
         # move old style CAT and df files to the new naming scheme
         if basename.split('-').last == "CAT" || basename.split('-').last == "df"
-          FileUtils.mv(upload_directory + "/" + file, upload_directory + "/" + basename + "-PDSC_ADMIN." + extension)
-          # TODO: catch if mv failed to rename the file. Raise an error.
+          begin
+            FileUtils.mv(upload_directory + "/" + file, upload_directory + "/" + basename + "-PDSC_ADMIN." + extension)
+          rescue
+            puts "WARNING: file #{file} skipped - not able to rename within upload folder" if verbose
+            next
+          end
 
           file = basename + "-PDSC_ADMIN." + extension
           basename, _extension, _coll_id, _item_id, _collection, _item = parse_file_name(file)

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -141,7 +141,8 @@ namespace :archive do
 
         # move old style CAT and df files to the new naming scheme
         if basename.split('-').last == "CAT" || basename.split('-').last == "df"
-          FileUtils.mv(destination_path + file, destination_path + "/" + basename + "-PDSC_ADMIN." + extension)
+          FileUtils.mv(upload_directory + "/" + file, upload_directory + "/" + basename + "-PDSC_ADMIN." + extension)
+          # TODO: catch if mv failed to rename the file. Raise an error.
 
           file = basename + "-PDSC_ADMIN." + extension
           basename, _extension, _coll_id, _item_id, _collection, _item = parse_file_name(file)

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -196,7 +196,20 @@ namespace :archive do
 
           puts "INFO: file #{file} copied into archive at #{destination_path}"
         else
-          # TODO: copy to the rejected place
+          rejected_directory = upload_directory + "Rejected/"
+          unless File.directory?(rejected_directory)
+            puts "WARNING: file #{file} not rejected - Rejected file folder #{rejected_directory} does not exist" if verbose
+            next
+          end
+
+          begin
+            FileUtils.cp(upload_directory + file, rejected_directory + file)
+          rescue
+            puts "WARNING: file #{file} skipped - not able to read it or write to #{rejected_directory + file}" if verbose
+            next
+          end
+
+          puts "INFO: file #{file} copied into rejected file folder at #{rejected_directory}"
         end
 
         # if everything went well, remove file from original directory

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -216,7 +216,8 @@ namespace :archive do
           puts "INFO: file #{file} copied into rejected file folder at #{rejected_directory}"
         end
 
-        # if everything went well, remove file from original directory
+        # if everything went well, meaning it was either moved into the archive, or moved to the rejected folder,
+        # remove file from original directory
         FileUtils.rm(upload_directory + file)
         puts "...done"
       end

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -294,6 +294,12 @@ namespace :archive do
           puts " >> #{e.backtrace}"
           next
         end
+
+        # REVIEW: Can this code throw an exception?
+        full_file_path = directory + "/" + file
+        essence = Essence.where(:item_id => item, :filename => file).first
+        media = Nabu::Media.new full_file_path
+        generate_derived_files(full_file_path, item, essence, extension, media)
       end
     end
     puts "===" if verbose

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -226,6 +226,17 @@ namespace :archive do
         # if everything went well, meaning it was either moved into the archive, or moved to the rejected folder,
         # remove file from original directory
         FileUtils.rm(upload_directory + file)
+
+        # Try doing generation of thumbnails. Failure to do this does not indicate a failure of the import process,
+        # so don't worry about success value.
+        # REVIEW: Can this code throw an exception?
+        if success
+          full_file_path = destination_path + "/" + file
+          essence = Essence.where(:item_id => item, :filename => file).first
+          media = Nabu::Media.new full_file_path
+          generate_derived_files(full_file_path, item, essence, extension, media)
+        end
+
         puts "...done"
       end
     end

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -175,10 +175,12 @@ namespace :archive do
           # extract media metadata from file
           puts "Inspecting file #{file}..."
           begin
+            # WIP: CONFIRMED as working for a valid file.
             success = import_metadata(upload_directory, file, item, extension, force_update)
           rescue => e
             puts "ERROR: file #{file} skipped - error importing metadata [#{e.message}]" if verbose
             puts " >> #{e.backtrace}"
+            # WIP: CONFIRMED as working.
             success = false
           end
         end
@@ -189,6 +191,7 @@ namespace :archive do
           # Action: Leave as-is.
           # make sure the archive directory for the collection and item exists
           # and move the file there
+          # WIP: CONFIRMED as working.
           begin
             FileUtils.mkdir_p(destination_path)
           rescue
@@ -198,6 +201,7 @@ namespace :archive do
 
           # Uncommon errors 3.
           # Action: Leave as-is.
+          # WIP: CONFIRMED as working.
           begin
             FileUtils.cp(upload_directory + file, destination_path + file)
           rescue
@@ -209,6 +213,7 @@ namespace :archive do
         else
           rejected_directory = upload_directory + "Rejected/"
           unless File.directory?(rejected_directory)
+            # WIP: CONFIRMED as working.
             puts "ERROR: file #{file} not rejected - Rejected file folder #{rejected_directory} does not exist" if verbose
             next
           end
@@ -216,6 +221,7 @@ namespace :archive do
           begin
             FileUtils.cp(upload_directory + file, rejected_directory + file)
           rescue
+            # WIP: CONFIRMED as working.
             puts "ERROR: file #{file} skipped - not able to read it or write to #{rejected_directory + file}" if verbose
             next
           end
@@ -438,6 +444,7 @@ namespace :archive do
     #use basename to avoid having item_id contain the extension
     coll_id, item_id, *remainder = basename.split('-')
     unless item_id
+      # WIP: CONFIRMED as working.
       puts "ERROR: could not parse collection id and item id for file #{file} - skipping" if verbose
       return [basename, extension, coll_id, item_id, nil, nil]
     end
@@ -447,6 +454,7 @@ namespace :archive do
     unless collection
       # Nabu Import Messages 6.
       # Action: Move to rejected folder.
+      # WIP: CONFIRMED as working.
       puts "ERROR: could not find collection id=#{coll_id} for file #{file} - skipping" if verbose
       return [basename, extension, coll_id, item_id, nil, nil]
     end
@@ -456,6 +464,7 @@ namespace :archive do
     unless item
       # Nabu Import Message 7.
       # Action: Move to rejected folder.
+      # WIP: CONFIRMED as working.
       puts "ERROR: could not find item pid=#{coll_id}-#{item_id} for file #{file} - skipping" if verbose
       return [basename, extension, coll_id, item_id, nil, nil]
     end
@@ -465,6 +474,7 @@ namespace :archive do
 
     # don't allow too few or too many dashes
     unless is_correctly_named_file || is_admin_file
+      # WIP: CONFIRMED as working.
       puts "ERROR: invalid filename for file #{file} - skipping" if verbose
       return [basename, extension, coll_id, item_id, nil, nil]
     end
@@ -501,6 +511,7 @@ namespace :archive do
     rescue => e
       # Nabu Import Messages 4.
       # Action: Move to rejected folder.
+      # WIP: CONFIRMED as working.
       puts "ERROR: unable to process file #{file} - skipping"
       puts" #{e}"
       return false
@@ -510,6 +521,7 @@ namespace :archive do
     when !essence.valid?
       # Nabu Import messages 5.
       # Action: Move to rejected folder.
+      # WIP: CONFIRMED as working.
       puts "ERROR: invalid metadata for #{file} of type #{extension} - skipping"
       essence.errors.each { |field, msg| puts "#{field}: #{msg}" }
       false

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -174,13 +174,13 @@ namespace :archive do
         if is_non_admin_file && success
           # extract media metadata from file
           puts "Inspecting file #{file}..."
-          # begin
+          begin
             success = import_metadata(upload_directory, file, item, extension, force_update)
-          # rescue => e
-          #   puts "ERROR: file #{file} skipped - error importing metadata [#{e.message}]" if verbose
-          #   puts " >> #{e.backtrace}"
-          #   success = false
-          # end
+          rescue => e
+            puts "ERROR: file #{file} skipped - error importing metadata [#{e.message}]" if verbose
+            puts " >> #{e.backtrace}"
+            success = false
+          end
         end
 
         # if meta data import was successful then we move to archive else move to rejected

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -175,7 +175,7 @@ namespace :archive do
           # extract media metadata from file
           puts "Inspecting file #{file}..."
           # begin
-            success = import_metadata(destination_path, file, item, extension, force_update)
+            success = import_metadata(upload_directory, file, item, extension, force_update)
           # rescue => e
           #   puts "ERROR: file #{file} skipped - error importing metadata [#{e.message}]" if verbose
           #   puts " >> #{e.backtrace}"

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -32,7 +32,7 @@ end
 # Coding style for log messages:
 # # Only use SUCCESS if an entire action has been completed successfully, not part of the action
 # # Use INFO for progress through part of an action
-# # WARNING and ERROR have their usual meaning
+# # ERROR has its usual meaning
 # # No need for a keyword for announcing a particular action is about to start,
 # # or has just finished
 namespace :archive do
@@ -124,7 +124,7 @@ namespace :archive do
         # Action: Move to rejected folder.
         # skip files of size 0 bytes
         unless File.size?("#{upload_directory}/#{file}")
-          puts "WARNING: file #{file} skipped, since it is empty" if verbose
+          puts "ERROR: file #{file} skipped, since it is empty" if verbose
           success = false
         end
 
@@ -138,7 +138,7 @@ namespace :archive do
         # Action: Move to rejected folder.
         # skip files with item_id longer than 30 chars, because OLAC can't deal with them
         if item_id.length > 30
-          puts "WARNING: file #{file} skipped - item id longer than 30 chars (OLAC incompatible)" if verbose
+          puts "ERROR: file #{file} skipped - item id longer than 30 chars (OLAC incompatible)" if verbose
           success = false
         end
 
@@ -149,7 +149,7 @@ namespace :archive do
           begin
             FileUtils.mv(upload_directory + "/" + file, upload_directory + "/" + basename + "-PDSC_ADMIN." + extension)
           rescue
-            puts "WARNING: file #{file} skipped - not able to rename within upload folder" if verbose
+            puts "ERROR: file #{file} skipped - not able to rename within upload folder" if verbose
             next
           end
 
@@ -169,7 +169,7 @@ namespace :archive do
           begin
             success = import_metadata(destination_path, file, item, extension, force_update)
           rescue => e
-            puts "WARNING: file #{file} skipped - error importing metadata [#{e.message}]" if verbose
+            puts "ERROR: file #{file} skipped - error importing metadata [#{e.message}]" if verbose
             puts " >> #{e.backtrace}"
             success = false
           end
@@ -185,7 +185,7 @@ namespace :archive do
             destination_path = Nabu::Application.config.archive_directory + "#{coll_id}/#{item_id}/"
             FileUtils.mkdir_p(destination_path)
           rescue
-            puts "WARNING: file #{file} skipped - not able to create directory #{destination_path}" if verbose
+            puts "ERROR: file #{file} skipped - not able to create directory #{destination_path}" if verbose
             next
           end
 
@@ -194,7 +194,7 @@ namespace :archive do
           begin
             FileUtils.cp(upload_directory + file, destination_path + file)
           rescue
-            puts "WARNING: file #{file} skipped - not able to read it or write to #{destination_path + file}" if verbose
+            puts "ERROR: file #{file} skipped - not able to read it or write to #{destination_path + file}" if verbose
             next
           end
 
@@ -202,14 +202,14 @@ namespace :archive do
         else
           rejected_directory = upload_directory + "Rejected/"
           unless File.directory?(rejected_directory)
-            puts "WARNING: file #{file} not rejected - Rejected file folder #{rejected_directory} does not exist" if verbose
+            puts "ERROR: file #{file} not rejected - Rejected file folder #{rejected_directory} does not exist" if verbose
             next
           end
 
           begin
             FileUtils.cp(upload_directory + file, rejected_directory + file)
           rescue
-            puts "WARNING: file #{file} skipped - not able to read it or write to #{rejected_directory + file}" if verbose
+            puts "ERROR: file #{file} skipped - not able to read it or write to #{rejected_directory + file}" if verbose
             next
           end
 
@@ -264,7 +264,7 @@ namespace :archive do
         end
 
         if ignore_update_file_prefixes.any? {|prefix| basename.start_with?(prefix) }
-          puts "WARNING: file #{file} skipped - suspected of being crash-prone"
+          puts "ERROR: file #{file} skipped - suspected of being crash-prone"
           next
         end
 
@@ -272,7 +272,7 @@ namespace :archive do
         begin
           import_metadata(directory, file, item, extension, force_update)
         rescue => e
-          puts "WARNING: file #{file} skipped - error importing metadata [#{e.message}]" if verbose
+          puts "ERROR: file #{file} skipped - error importing metadata [#{e.message}]" if verbose
           puts " >> #{e.backtrace}"
           next
         end
@@ -501,7 +501,7 @@ namespace :archive do
       puts "SUCCESS: file #{file} metadata imported into Nabu"
       true
     when essence.changed?
-      puts "WARNING: file #{file} metadata is different to DB - use 'FORCE=true archive:update_file' to update"
+      puts "ERROR: file #{file} metadata is different to DB - use 'FORCE=true archive:update_file' to update"
       puts essence.changes.inspect
       true
     else

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -476,7 +476,8 @@ namespace :archive do
     end
 
     #attempt to generate derived files such as lower quality versions or thumbnails, continue even if this fails
-    generate_derived_files(full_file_path, item, essence, extension, media)
+    # WIP: Call this from the rake tasks.
+    # generate_derived_files(full_file_path, item, essence, extension, media)
 
     # update essence entry with metadata from file
     begin

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -479,12 +479,9 @@ namespace :archive do
 
     # extract media metadata from file
     media = Nabu::Media.new full_file_path
-    unless media
-      # Nabu Import Messages 3.
-      # Action: Move to rejected folder.
-      puts "ERROR: was not able to parse #{full_file_path} of type #{extension} - skipping"
-      return false
-    end
+
+    # Nabu Import Messages 3 can't possibly happen. Nabu::Media.new either returns with something truthy,
+    # or causes an exception.
 
     # find essence file in Nabu DB; if there is none, create a new one
     essence = Essence.where(:item_id => item, :filename => file).first

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -492,10 +492,6 @@ namespace :archive do
       essence = Essence.new(:item => item, :filename => file)
     end
 
-    #attempt to generate derived files such as lower quality versions or thumbnails, continue even if this fails
-    # WIP: Call this from the rake tasks.
-    # generate_derived_files(full_file_path, item, essence, extension, media)
-
     # update essence entry with metadata from file
     begin
       essence.mimetype   = media.mimetype

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -140,6 +140,7 @@ namespace :archive do
         # Uncommon errors 1.
         # Action: Move to rejected folder.
         # skip files with item_id longer than 30 chars, because OLAC can't deal with them
+        # WIP: CONFIRMED as working.
         if success && item_id.length > 30
           puts "ERROR: file #{file} skipped - item id longer than 30 chars (OLAC incompatible)" if verbose
           success = false
@@ -148,6 +149,7 @@ namespace :archive do
         puts '---------------------------------------------------------------'
 
         # move old style CAT and df files to the new naming scheme
+        # WIP: Not tested.
         if basename.split('-').last == "CAT" || basename.split('-').last == "df"
           begin
             FileUtils.mv(upload_directory + "/" + file, upload_directory + "/" + basename + "-PDSC_ADMIN." + extension)

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -174,13 +174,13 @@ namespace :archive do
         if is_non_admin_file && success
           # extract media metadata from file
           puts "Inspecting file #{file}..."
-          begin
+          # begin
             success = import_metadata(destination_path, file, item, extension, force_update)
-          rescue => e
-            puts "ERROR: file #{file} skipped - error importing metadata [#{e.message}]" if verbose
-            puts " >> #{e.backtrace}"
-            success = false
-          end
+          # rescue => e
+          #   puts "ERROR: file #{file} skipped - error importing metadata [#{e.message}]" if verbose
+          #   puts " >> #{e.backtrace}"
+          #   success = false
+          # end
         end
 
         # if meta data import was successful then we move to archive else move to rejected

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -139,7 +139,7 @@ namespace :archive do
         # Uncommon errors 1.
         # Action: Move to rejected folder.
         # skip files with item_id longer than 30 chars, because OLAC can't deal with them
-        if item_id.length > 30
+        if success && item_id.length > 30
           puts "ERROR: file #{file} skipped - item id longer than 30 chars (OLAC incompatible)" if verbose
           success = false
         end

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -108,6 +108,7 @@ namespace :archive do
         # Nabu Import Messages 9.
         # Action: Leave as-is.
         # skip files that can't be read
+        # WIP: CONFIRMED as working.
         unless File.readable?("#{upload_directory}/#{file}")
           puts "ERROR: file #{file} skipped, since it's not readable" if verbose
           next
@@ -115,6 +116,7 @@ namespace :archive do
 
         # Action: Leave as-is.
         # Skip files that are currently uploading
+        # WIP: CONFIRMED as working.
         last_updated = File.stat("#{upload_directory}/#{file}").mtime
         if (Time.now - last_updated) < 60*10
           next

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -125,6 +125,7 @@ namespace :archive do
         # Nabu Import Messages 8.
         # Action: Move to rejected folder.
         # skip files of size 0 bytes
+        # WIP: CONFIRMED as working.
         unless File.size?("#{upload_directory}/#{file}")
           puts "ERROR: file #{file} skipped, since it is empty" if verbose
           success = false

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -164,6 +164,9 @@ namespace :archive do
 
         is_non_admin_file = basename.split('-').last != "PDSC_ADMIN"
 
+        # coll_id or item_id being nil should not be a problem, as destination_path is only used if success is true
+        destination_path = Nabu::Application.config.archive_directory + "#{coll_id}/#{item_id}/"
+
         # Action: If it's PDSC_ADMIN, move the file
         # Action: If it fails to import, move to rejected.
         # files of the pattern "#{collection_id}-#{item_id}-xxx-PDSC_ADMIN.xxx"
@@ -187,7 +190,6 @@ namespace :archive do
           # make sure the archive directory for the collection and item exists
           # and move the file there
           begin
-            destination_path = Nabu::Application.config.archive_directory + "#{coll_id}/#{item_id}/"
             FileUtils.mkdir_p(destination_path)
           rescue
             puts "ERROR: file #{file} skipped - not able to create directory #{destination_path}" if verbose

--- a/spec/models/essence_spec.rb
+++ b/spec/models/essence_spec.rb
@@ -2,19 +2,20 @@
 #
 # Table name: essences
 #
-#  id         :integer          not null, primary key
-#  item_id    :integer
-#  filename   :string(255)
-#  mimetype   :string(255)
-#  bitrate    :integer
-#  samplerate :integer
-#  size       :integer
-#  duration   :float
-#  channels   :integer
-#  fps        :integer
-#  created_at :datetime
-#  updated_at :datetime
-#  doi        :string(255)
+#  id                      :integer          not null, primary key
+#  item_id                 :integer
+#  filename                :string(255)
+#  mimetype                :string(255)
+#  bitrate                 :integer
+#  samplerate              :integer
+#  size                    :integer
+#  duration                :float
+#  channels                :integer
+#  fps                     :integer
+#  created_at              :datetime
+#  updated_at              :datetime
+#  doi                     :string(255)
+#  derived_files_generated :boolean
 #
 
 require 'spec_helper'


### PR DESCRIPTION
Move unsuccessful database imports into the rejected folder, rather than leaving them as-is or deleting them.

Rather than creating a massive refactor, the code was changed to do the following:

* Copy after a record is created, not beforehand
* Set `success` to `true` if the file should be moved into the archive
* Set `success`to `false` if the file should be moved into the rejected folder
* Skip the loop iteration if the file should be left as-is in its current position

Changes made along the way:

* Check for recent uploads (to leave as-is) before checking for empty files (to be moved to rejected)
* If a file is an old-style admin file, after renaming it, update the variables about the file accordingly, so other parts of the process will handle it correctly
* Refactoring for readability

To review:

* It might be possible for one file to overwrite another file. Not just in the happy path scenario of a new file being copied into the archive on top of an old one, but an unconventionally named archive file overwriting another one, or a rejected file overwriting another rejected file. Is that a problem?
* Is the logic of the script consistent with what is wanted?
* I haven't tested that the script does what I expect it to. I want to confirm the logic appears to be consistent with what is wanted before it is tested out.
* Are the error and non-error messages acceptable? Are there any we should modify or get rid of?
* Shall I get rid of comments describing each scenario, such as "Nabu Import Messages 7." and "Action: Move to rejected folder."?
