### PR TITLE
fix for #626 bulk update to remove attributes from fields

### DIFF
--- a/app/assets/javascripts/select2_setup.js.coffee
+++ b/app/assets/javascripts/select2_setup.js.coffee
@@ -66,4 +66,8 @@
     options['createSearchChoice'] = (term) ->
       return {id: 'NEWCONTACT:'+term, text: term}
 
+  data = $(element).data('data')
+  if data
+    options['data'] = data
+
   $(element).select2(options)

--- a/app/controllers/concerns/item_query_builder.rb
+++ b/app/controllers/concerns/item_query_builder.rb
@@ -114,7 +114,12 @@ module ItemQueryBuilder
         clause_sql += ' ?'
 
         if TYPES_FOR_FIELDS[field] == 'date'
-          input_value = DateTime.parse(input_value).strftime('%Y-%m-%d')
+          begin
+            input_value = DateTime.parse(input_value).strftime('%Y-%m-%d')
+          rescue Exception => e
+            Rails.logger.error e.message
+            Rails.logger.error e.backtrace.first(10).join("\n")
+          end
         end
 
         value_sql = clause_operator.include?('like') ? "%#{input_value}%" : input_value
@@ -132,6 +137,8 @@ module ItemQueryBuilder
         query.push clause_sql
       end
     end
+    Rails.logger.debug "Query: #{query}"
+    Rails.logger.debug "Values: #{values}"
     results = results.includes(joins.uniq).where(query.join(' '), *values)
     if params[:exclusions].present?
       exclusions = params[:exclusions].split(',')

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -416,7 +416,7 @@ class ItemsController < ApplicationController
   def bulk_deletable_relation(relation, associated_resource, associated_resource_id, items)
     ids = relation.where(item_id: items.map(&:id))
             .group_by(&associated_resource_id)
-            .select { |k,v| v.size == items.size }.keys
+            .keys
     associated_resource.where(id: ids).map do |resource|
       { id: resource.id, text: resource.name }
     end if ids.present?

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -103,7 +103,10 @@ class Item < ActiveRecord::Base
     :bulk_edit_append_dialect, :bulk_edit_append_original_media, :bulk_edit_append_ingest_notes,
     :bulk_edit_append_tracking, :bulk_edit_append_access_narrative, :bulk_edit_append_admin_comment,
     :bulk_edit_append_country_ids, :bulk_edit_append_subject_language_ids, :bulk_edit_append_content_language_ids,
-    :bulk_edit_append_admin_ids, :bulk_edit_append_user_ids, :bulk_edit_append_data_category_ids, :bulk_edit_append_data_type_ids
+    :bulk_edit_append_admin_ids, :bulk_edit_append_user_ids, :bulk_edit_append_data_category_ids, :bulk_edit_append_data_type_ids,
+
+    :bulk_delete_country_ids, :bulk_delete_subject_language_ids,
+    :bulk_delete_content_language_ids, :bulk_delete_data_category_ids, :bulk_delete_data_type_ids
   ]
   attr_reader(*bulk)
   attr_accessible :identifier, :title, :external, :url, :description, :region, :collection_id,
@@ -615,5 +618,9 @@ class Item < ActiveRecord::Base
 
   def access_class
     AccessCondition.access_classification(access_condition)
+  end
+
+  def bulk_deleteable
+    @bulk_deleteable ||= {}
   end
 end

--- a/app/services/bulk_update_items_service.rb
+++ b/app/services/bulk_update_items_service.rb
@@ -16,6 +16,10 @@ class BulkUpdateItemsService
         appending[k] = existing.present? ? existing + v : v
       end
 
+      @deletable.each_pair do |k, v|
+        item.send("#{k}=", item.send(k) - v)
+      end
+
       if item.update_attributes(@updates.merge(appending))
         ItemCatalogService.new(item).save_file
       else
@@ -53,6 +57,14 @@ class BulkUpdateItemsService
     @updates.each_pair do |k, v|
       if k =~ /^bulk_edit_append_(.*)/
         @appendable[$1] = @updates[$1] if v == '1' && @updates[$1].present?
+        @updates.delete(k)
+      end
+    end
+
+    @deletable = {}
+    @updates.each_pair do |k, v|
+      if k =~ /^bulk_delete_(.*)/
+        @deletable[$1] = v.map(&:to_i)
         @updates.delete(k)
       end
     end

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -353,6 +353,6 @@
 
         - if @item.bulk_deleteable[:data_types].present?
           %tr
-            %th= f.label :bulk_delete_data_type_ids, 'Data Categories'
+            %th= f.label :bulk_delete_data_type_ids, 'Data Types'
             %td= f.hidden_field :bulk_delete_data_type_ids,
               data: { placeholder: 'Choose data types to delete', data: @item.bulk_deleteable[:data_types].to_json, multiple: true }, class: 'select2'

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -322,3 +322,37 @@
           %td.append
             %small Append
             = f.check_box :bulk_edit_append_admin_comment
+
+  - if params[:action] == 'bulk_edit'
+    %fieldset
+      %legend Bulk Delete
+      %table.form
+        - if @item.bulk_deleteable[:countries].present?
+          %tr
+            %th= f.label :bulk_delete_country_ids, 'Countries'
+            %td= f.hidden_field :bulk_delete_country_ids,
+              data: { placeholder: 'Choose countries to delete', data: @item.bulk_deleteable[:countries].to_json, multiple: true }, class: 'select2'
+
+        - if @item.bulk_deleteable[:subject_languages].present?
+          %tr
+            %th= f.label :bulk_delete_subject_language_ids, 'Subject Languages'
+            %td= f.hidden_field :bulk_delete_subject_language_ids,
+              data: { placeholder: 'Choose subject languages to delete', data: @item.bulk_deleteable[:subject_languages].to_json, multiple: true }, class: 'select2'
+
+        - if @item.bulk_deleteable[:content_languages].present?
+          %tr
+            %th= f.label :bulk_delete_content_language_ids, 'Content Languages'
+            %td= f.hidden_field :bulk_delete_content_language_ids,
+              data: { placeholder: 'Choose content languages to delete', data: @item.bulk_deleteable[:content_languages].to_json, multiple: true }, class: 'select2'
+
+        - if @item.bulk_deleteable[:data_categories].present?
+          %tr
+            %th= f.label :bulk_delete_data_category_ids, 'Data Categories'
+            %td= f.hidden_field :bulk_delete_data_category_ids,
+              data: { placeholder: 'Choose data categories to delete', data: @item.bulk_deleteable[:data_categories].to_json, multiple: true }, class: 'select2'
+
+        - if @item.bulk_deleteable[:data_types].present?
+          %tr
+            %th= f.label :bulk_delete_data_type_ids, 'Data Categories'
+            %td= f.hidden_field :bulk_delete_data_type_ids,
+              data: { placeholder: 'Choose data types to delete', data: @item.bulk_deleteable[:data_types].to_json, multiple: true }, class: 'select2'


### PR DESCRIPTION
Added new fieldset in bulk edit mode to allow user to select *common* values for associated attributes
Currently this feature works for countries, subject/content languages, data categories and data types but trivial to add similar functionality for similar associations i.e. users, admin users and agents
<img width="593" alt="screen shot 2017-09-22 at 00 32 24" src="https://user-images.githubusercontent.com/1011517/30701819-a084ca2c-9f2e-11e7-8786-1f299c854e6f.png">
