### PR TITLE
update or replace broken or outdated links

### DIFF
--- a/app/views/page/apidoc.html.haml
+++ b/app/views/page/apidoc.html.haml
@@ -15,7 +15,7 @@
 .page-box
 
   %h3
-    = link_to 'RIF-CS', 'http://www.ands.org.au/resource/rif-cs.html'
+    = link_to 'RIF-CS', 'https://www.ands.org.au/online-services/rif-cs-schema'
 
   %p
     A RIF-CS feed is available at
@@ -28,7 +28,7 @@
 
   %p
     About RIF-CS:
-    = link_to 'http://ands.org.au/guides/cpguide/cpgrifcs.html', 'http://ands.org.au/guides/cpguide/cpgrifcs.html'
+    = link_to 'https://documentation.ands.org.au/display/DOC/Content+Providers+Guide', 'https://documentation.ands.org.au/display/DOC/Content+Providers+Guide'
 
 %h2 Harvesting Items
 
@@ -68,7 +68,7 @@
 
   %p
     Our GraphQL API is available at:
-    = link_to 'http://catalog.paradisec.org.au/graphql', 'http://catalog.paradisec.org.au/graphql'
+    = link_to 'http://catalog.paradisec.org.au/graphiql', 'http://catalog.paradisec.org.au/graphiql'
 
   %p
     A very simple search for an item based on its identifier would look like this:


### PR DESCRIPTION
There's a few broken or outdated links on the API page. In particular the link to the GraphQL sandbox (graphiql _not_ graphql)