### PR TITLE
feat(api): expose active admin messages on /announcements

### DIFF
--- a/docker/oni.json
+++ b/docker/oni.json
@@ -10,7 +10,8 @@
       "launcher": "Acknowledgement of Country"
     },
     "features": {
-      "errorPageImage": false
+      "errorPageImage": false,
+      "hasAnnouncements": true
     },
     "logoFilename": "/logo.jpg",
     "navHeight": "90px",


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/oni/announcements` returning `{ announcements: [{ id, message }] }` for currently active rows in `admin_messages`.
- Filters with the same `start_at <= now <= finish_at` window already used by `application_helper#admin_messages`, ordered by `start_at DESC`.
- Auth-optional (inherits `doorkeeper_authorize_optional` from `ApiController`) so anonymous Oni visitors can see the banner — matches Nabu's own public layout behaviour.

Unblocks the matching frontend banner work in oni-ui. The Oni feature is dark by default (`ui.features.hasAnnouncements: false`), so this PR is safe to ship independently.

## Test plan

- [ ] `rails console` → `AdminMessage.create!(message: 'Test', start_at: 1.minute.ago, finish_at: 1.hour.from_now)`
- [ ] `curl http://localhost:3000/api/v1/oni/announcements` returns the row
- [ ] Edit `start_at` to the future → row disappears from response
- [ ] Same with a Bearer token → identical response (auth optional)