### PR TITLE
Permissions Phase 1: separate attribution from access (#1127)

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -167,6 +167,7 @@ RSpec/MessageSpies:
 RSpec/MultipleExpectations:
   Exclude:
     - 'spec/concerns/identifiable_by_doi_spec.rb'
+    - 'spec/controllers/collections_controller_spec.rb'
     - 'spec/controllers/essences_controller_spec.rb'
     - 'spec/controllers/items_controller_spec.rb'
     - 'spec/controllers/terms_controller_spec.rb'

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -399,12 +399,12 @@ class CollectionsController < ApplicationController
       :bulk_edit_append_access_narrative, :bulk_edit_append_metadata_source,
       :bulk_edit_append_orthographic_notes, :bulk_edit_append_media, :bulk_edit_append_comments,
       :bulk_edit_append_tape_location, # :bulk_edit_append_grant_identifier,
-      :bulk_edit_append_country_ids, :bulk_edit_append_language_ids, :bulk_edit_append_admin_ids,
+      :bulk_edit_append_country_ids, :bulk_edit_append_language_ids,
 
       :complete, :private, :access_narrative, :metadata_source, :orthographic_notes, :media, :comments,
       :deposit_form_received, :tape_location,
 
-      { language_ids: [], country_ids: [], admin_ids: [],
+      { language_ids: [], country_ids: [],
         grants_attributes: [
           :id,
           :funding_body_id,
@@ -412,8 +412,8 @@ class CollectionsController < ApplicationController
           :_destroy
         ] }
     ]
-    # Only admins may assign or remove the read-only grant.
-    permitted << { user_ids: [] } if current_user.admin?
+    # Only admins may assign or remove grants (edit + read-only access).
+    permitted += [:bulk_edit_append_admin_ids, { admin_ids: [], user_ids: [] }] if current_user.admin?
 
     params.require(:collection).permit(*permitted)
   end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -390,30 +390,32 @@ class CollectionsController < ApplicationController
   end
 
   def collection_params
-    params
-      .require(:collection)
-      .permit(
-        :identifier, :title, :description, :region,
-        :north_limit, :south_limit, :west_limit, :east_limit,
-        :collector_id, :operator_id, :university_id, :field_of_research_id,
-        :access_condition_id,
-        :bulk_edit_append_title, :bulk_edit_append_description, :bulk_edit_append_region,
-        :bulk_edit_append_access_narrative, :bulk_edit_append_metadata_source,
-        :bulk_edit_append_orthographic_notes, :bulk_edit_append_media, :bulk_edit_append_comments,
-        :bulk_edit_append_tape_location, # :bulk_edit_append_grant_identifier,
-        :bulk_edit_append_country_ids, :bulk_edit_append_language_ids, :bulk_edit_append_admin_ids,
+    permitted = [
+      :identifier, :title, :description, :region,
+      :north_limit, :south_limit, :west_limit, :east_limit,
+      :collector_id, :operator_id, :university_id, :field_of_research_id,
+      :access_condition_id,
+      :bulk_edit_append_title, :bulk_edit_append_description, :bulk_edit_append_region,
+      :bulk_edit_append_access_narrative, :bulk_edit_append_metadata_source,
+      :bulk_edit_append_orthographic_notes, :bulk_edit_append_media, :bulk_edit_append_comments,
+      :bulk_edit_append_tape_location, # :bulk_edit_append_grant_identifier,
+      :bulk_edit_append_country_ids, :bulk_edit_append_language_ids, :bulk_edit_append_admin_ids,
 
-        :complete, :private, :access_narrative, :metadata_source, :orthographic_notes, :media, :comments,
-        :deposit_form_received, :tape_location,
+      :complete, :private, :access_narrative, :metadata_source, :orthographic_notes, :media, :comments,
+      :deposit_form_received, :tape_location,
 
-        language_ids: [], country_ids: [], admin_ids: [],
+      { language_ids: [], country_ids: [], admin_ids: [],
         grants_attributes: [
           :id,
           :funding_body_id,
           :grant_identifier,
           :_destroy
-        ]
-      )
+        ] }
+    ]
+    # Only admins may assign or remove the read-only grant.
+    permitted << { user_ids: [] } if current_user.admin?
+
+    params.require(:collection).permit(*permitted)
   end
 end
 # rubocop:enable Metrics/ClassLength,Metrics/MethodLength

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -417,34 +417,42 @@ class ItemsController < ApplicationController
   def item_params
     tidy_params! if %w[create update bulk_update].include?(params[:action])
 
-    params
-      .require(:item)
-      .permit(
-        :identifier, :title, :external, :url, :description, :region, :collection_id,
-        :north_limit, :south_limit, :west_limit, :east_limit,
-        :collector_id, :university_id, :operator_id,
-        :country_ids, :data_category_ids, :data_type_ids,
-        :content_language_ids, :subject_language_ids,
-        :admin_ids, :agent_ids, :user_ids,
-        :access_condition_id,
-        :access_narrative, :private,
-        :admin_comment,
-        :originated_on, :originated_on_narrative, :language,
-        :dialect, :discourse_type_id,
-        :metadata_exportable, :born_digital, :tapes_returned,
-        :original_media, :ingest_notes, :tracking,
-        :received_on, :digitised_on, :metadata_imported_on, :metadata_exported_on,
-        :bulk_edit_append_title, :bulk_edit_append_description, :bulk_edit_append_region,
-        :bulk_edit_append_originated_on_narrative, :bulk_edit_append_url, :bulk_edit_append_language,
-        :bulk_edit_append_dialect, :bulk_edit_append_original_media, :bulk_edit_append_ingest_notes,
-        :bulk_edit_append_tracking, :bulk_edit_append_access_narrative, :bulk_edit_append_admin_comment,
-        :bulk_edit_append_country_ids, :bulk_edit_append_subject_language_ids, :bulk_edit_append_content_language_ids,
-        :bulk_edit_append_admin_ids, :bulk_edit_append_user_ids, :bulk_edit_append_data_category_ids, :bulk_edit_append_data_type_ids,
-        :bulk_delete_country_ids, :bulk_delete_subject_language_ids,
-        :bulk_delete_content_language_ids, :bulk_delete_data_category_ids, :bulk_delete_data_type_ids,
+    permitted = [
+      :identifier, :title, :external, :url, :description, :region, :collection_id,
+      :north_limit, :south_limit, :west_limit, :east_limit,
+      :collector_id, :university_id, :operator_id,
+      :country_ids, :data_category_ids, :data_type_ids,
+      :content_language_ids, :subject_language_ids,
+      :agent_ids,
+      :access_condition_id,
+      :access_narrative, :private,
+      :admin_comment,
+      :originated_on, :originated_on_narrative, :language,
+      :dialect, :discourse_type_id,
+      :metadata_exportable, :born_digital, :tapes_returned,
+      :original_media, :ingest_notes, :tracking,
+      :received_on, :digitised_on, :metadata_imported_on, :metadata_exported_on,
+      :bulk_edit_append_title, :bulk_edit_append_description, :bulk_edit_append_region,
+      :bulk_edit_append_originated_on_narrative, :bulk_edit_append_url, :bulk_edit_append_language,
+      :bulk_edit_append_dialect, :bulk_edit_append_original_media, :bulk_edit_append_ingest_notes,
+      :bulk_edit_append_tracking, :bulk_edit_append_access_narrative, :bulk_edit_append_admin_comment,
+      :bulk_edit_append_country_ids, :bulk_edit_append_subject_language_ids, :bulk_edit_append_content_language_ids,
+      :bulk_edit_append_data_category_ids, :bulk_edit_append_data_type_ids,
+      :bulk_delete_country_ids, :bulk_delete_subject_language_ids,
+      :bulk_delete_content_language_ids, :bulk_delete_data_category_ids, :bulk_delete_data_type_ids,
 
-        item_agents_attributes: {},
-        country_ids: [], subject_language_ids: [], content_language_ids: [], data_category_ids: [], data_type_ids: [], admin_ids: [], user_ids: []
-      )
+      { item_agents_attributes: {},
+        country_ids: [], subject_language_ids: [], content_language_ids: [], data_category_ids: [], data_type_ids: [] }
+    ]
+    # Only admins may assign or remove grants (edit + read/download access).
+    if current_user.admin?
+      permitted += [
+        :admin_ids, :user_ids,
+        :bulk_edit_append_admin_ids, :bulk_edit_append_user_ids,
+        { admin_ids: [], user_ids: [] }
+      ]
+    end
+
+    params.require(:item).permit(*permitted)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,10 +4,15 @@ class UsersController < ApplicationController
   respond_to :json
 
   def index
-    @users = @users
-      .where(contact_only: true)
-      .or(User.where(contact_only: false).where.not(confirmed_at: nil))
-      .order('first_name, last_name')
+    # Grant pickers (exclude_contacts) only offer real, confirmed users; contacts can never hold a grant.
+    # Attribution pickers (collector/operator) still include contacts.
+    @users =
+      if params[:exclude_contacts]
+        @users.where(contact_only: false).where.not(confirmed_at: nil)
+      else
+        @users.where(contact_only: true).or(User.where(contact_only: false).where.not(confirmed_at: nil))
+      end
+    @users = @users.order('first_name, last_name')
     match = "%#{params[:q]}%"
     @users = @users.where(User.arel_table[:first_name].matches(match))
       .or(@users.where(User.arel_table[:last_name].matches(match)))

--- a/app/helpers/custom_form_builder.rb
+++ b/app/helpers/custom_form_builder.rb
@@ -7,6 +7,7 @@ class CustomFormBuilder < ActionView::Helpers::FormBuilder
     }
     html_data[:required] = true if options[:required]
     html_data[:tags] = true if options[:tags]
+    html_data[:'exclude-contacts'] = true if options[:exclude_contacts]
 
     select_options = {}
     select_options[:multiple] = options[:multiple] if options[:multiple]

--- a/app/javascript/custom/choices_setup.ts
+++ b/app/javascript/custom/choices_setup.ts
@@ -25,6 +25,7 @@ const setupAjaxSearch = (element: HTMLSelectElement, instance: Choices) => {
   const extraName = element.dataset.extraName;
   const extraSelector = element.dataset.extraSelector;
   const hasTags = element.dataset.tags === 'true';
+  const excludeContacts = element.dataset.excludeContacts === 'true';
   let abortController: AbortController | null = null;
 
   const doSearch = debounce(async (_detail: unknown) => {
@@ -34,6 +35,10 @@ const setupAjaxSearch = (element: HTMLSelectElement, instance: Choices) => {
     abortController = new AbortController();
 
     const params = new URLSearchParams({ q: searchTerm });
+
+    if (excludeContacts) {
+      params.append('exclude_contacts', 'true');
+    }
 
     if (extraName && extraSelector) {
       const extraElement = document.querySelector(extraSelector) as HTMLSelectElement | null;

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -71,10 +71,6 @@ class Ability
     can :read, Entity, entity_type: 'Collection', collection: { items: { item_admins: { user_id: user.id } } }
     can %i[read update], Collection, collection_admins: { user_id: user.id }
     can :read, Entity, entity_type: 'Collection', collection: { collection_admins: { user_id: user.id } }
-    can %i[read update], Collection, operator_id: user.id
-    can :read, Entity, entity_type: 'Collection', collection: { operator_id: user.id }
-    can %i[read update], Collection, collector_id: user.id
-    can :read, Entity, entity_type: 'Collection', collection: { collector_id: user.id }
 
     # Only admins can create a collection
     cannot :create, Collection
@@ -97,16 +93,8 @@ class Ability
     can %i[read data], Item, item_admins: { user_id: user.id }
     can :read, Entity, entity_type: 'Item', item: { item_admins: { user_id: user.id } }
 
-    can :manage, Item, collector_id: user.id
-    can :read, Entity, entity_type: 'Item', item: { collector_id: user.id }
-    can :manage, Item, operator_id: user.id
-    can :read, Entity, entity_type: 'Item', item: { operator_id: user.id }
     can :manage, Item, collection: { collection_admins: { user_id: user.id } }
     can :read, Entity, entity_type: 'Item', item: { collection: { collection_admins: { user_id: user.id } } }
-    can :manage, Item, collection: { collector_id: user.id }
-    can :read, Entity, entity_type: 'Item', item: { collection: { collector_id: user.id } }
-    can :manage, Item, collection: { operator_id: user.id }
-    can :read, Entity, entity_type: 'Item', item: { collection: { operator_id: user.id } }
     can :manage, Item, item_admins: { user_id: user.id }
     can :read, Entity, entity_type: 'Item', item: { item_admins: { user_id: user.id } }
 
@@ -131,8 +119,6 @@ class Ability
       item: { access_condition: { name: 'Open (subject to agreeing to PDSC access conditions)' } }
     can %i[read download], Entity, entity_type: 'Essence', essence: { item: { access_condition: { name: 'Open (subject to agreeing to PDSC access conditions)' } } }
     can %i[read download], Entity, entity_type: 'Essence', essence: { item: { collection: { collection_admins: { user_id: user.id } } } }
-    can %i[read download display], Essence, item: { collection: { collector_id: user.id } }
-    can %i[read download], Entity, entity_type: 'Essence', essence: { item: { collection: { collector_id: user.id } } }
     can %i[read download display], Essence, item: { item_admins: { user_id: user.id } }
     can %i[read download], Entity, entity_type: 'Essence', essence: { item: { item_admins: { user_id: user.id } } }
     can %i[read download display], Essence, item: { item_users: { user_id: user.id } }
@@ -144,11 +130,7 @@ class Ability
     # EssenceAnnotation
     #############
 
-    can :manage, EssenceAnnotation, target_essence: { item: { collector_id: user.id } }
-    can :manage, EssenceAnnotation, target_essence: { item: { operator_id: user.id } }
     can :manage, EssenceAnnotation, target_essence: { item: { item_admins: { user_id: user.id } } }
-    can :manage, EssenceAnnotation, target_essence: { item: { collection: { collector_id: user.id } } }
-    can :manage, EssenceAnnotation, target_essence: { item: { collection: { operator_id: user.id } } }
     can :manage, EssenceAnnotation, target_essence: { item: { collection: { collection_admins: { user_id: user.id } } } }
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -64,13 +64,17 @@ class Ability
     can :read, Collection, private: false
     can :read, Entity, entity_type: 'Collection', collection: { private: false }
 
-    # Only collection_admins can manage a collection
+    # Members of any item in a collection can read the collection
     can :read, Collection, items: { item_users: { user_id: user.id } }
     can :read, Entity, entity_type: 'Collection', collection: { items: { item_users: { user_id: user.id } } }
     can :read, Collection, items: { item_admins: { user_id: user.id } }
     can :read, Entity, entity_type: 'Collection', collection: { items: { item_admins: { user_id: user.id } } }
     can %i[read update], Collection, collection_admins: { user_id: user.id }
     can :read, Entity, entity_type: 'Collection', collection: { collection_admins: { user_id: user.id } }
+
+    # collection_users are read-only grantees of the whole collection
+    can :read, Collection, collection_users: { user_id: user.id }
+    can :read, Entity, entity_type: 'Collection', collection: { collection_users: { user_id: user.id } }
 
     # Only admins can create a collection
     cannot :create, Collection
@@ -92,6 +96,9 @@ class Ability
     can :read, Entity, entity_type: 'Item', item: { item_users: { user_id: user.id } }
     can %i[read data], Item, item_admins: { user_id: user.id }
     can :read, Entity, entity_type: 'Item', item: { item_admins: { user_id: user.id } }
+
+    can %i[read data], Item, collection: { collection_users: { user_id: user.id } }
+    can :read, Entity, entity_type: 'Item', item: { collection: { collection_users: { user_id: user.id } } }
 
     can :manage, Item, collection: { collection_admins: { user_id: user.id } }
     can :read, Entity, entity_type: 'Item', item: { collection: { collection_admins: { user_id: user.id } } }
@@ -118,7 +125,10 @@ class Ability
     can %i[read download display entities], Essence,
       item: { access_condition: { name: 'Open (subject to agreeing to PDSC access conditions)' } }
     can %i[read download], Entity, entity_type: 'Essence', essence: { item: { access_condition: { name: 'Open (subject to agreeing to PDSC access conditions)' } } }
+    can %i[read download display], Essence, item: { collection: { collection_admins: { user_id: user.id } } }
     can %i[read download], Entity, entity_type: 'Essence', essence: { item: { collection: { collection_admins: { user_id: user.id } } } }
+    can %i[read download display], Essence, item: { collection: { collection_users: { user_id: user.id } } }
+    can %i[read download], Entity, entity_type: 'Essence', essence: { item: { collection: { collection_users: { user_id: user.id } } } }
     can %i[read download display], Essence, item: { item_admins: { user_id: user.id } }
     can %i[read download], Entity, entity_type: 'Essence', essence: { item: { item_admins: { user_id: user.id } } }
     can %i[read download display], Essence, item: { item_users: { user_id: user.id } }

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -91,6 +91,9 @@ class Collection < ApplicationRecord
   has_many :collection_admins, dependent: :destroy, autosave: true
   has_many :admins, through: :collection_admins, validate: true, source: :user, autosave: true
 
+  has_many :collection_users, dependent: :destroy, autosave: true
+  has_many :users, through: :collection_users, validate: true, source: :user, autosave: true
+
   # require presence of these three fields
   validates :identifier,
             presence: true,
@@ -210,11 +213,11 @@ class Collection < ApplicationRecord
   end
 
   def self.search_includes
-    [:collector, :countries, :languages, :university, :admins, items: [:admins, :users]]
+    [:collector, :countries, :languages, :university, :admins, :users, items: [:admins, :users]]
   end
 
   def self.search_user_fields
-    %i[admin_ids item_admin_ids item_user_ids]
+    %i[admin_ids user_ids item_admin_ids item_user_ids]
   end
 
   def self.search_agg_fields
@@ -239,7 +242,7 @@ class Collection < ApplicationRecord
     %i[title description]
   end
   scope :search_import, lambda {
-                          includes(:university, :collector, :operator, :field_of_research, :languages, :countries, :admins, :grants, :access_condition, :content_languages, :essences, items: %i[admins users])
+                          includes(:university, :collector, :operator, :field_of_research, :languages, :countries, :admins, :users, :grants, :access_condition, :content_languages, :essences, items: %i[admins users])
                         }
 
   def search_data
@@ -291,6 +294,7 @@ class Collection < ApplicationRecord
       country_ids: countries.map(&:id).uniq,
       language_ids: languages.map(&:id).uniq,
       admin_ids: admins.map(&:id).uniq,
+      user_ids: users.map(&:id).uniq,
       item_admin_ids: items.flat_map(&:admin_ids).uniq,
       item_user_ids: items.flat_map(&:user_ids).uniq,
       access_condition_id:,

--- a/app/models/collection_admin.rb
+++ b/app/models/collection_admin.rb
@@ -23,6 +23,8 @@
 #
 
 class CollectionAdmin < ApplicationRecord
+  include RejectsContactGrants
+
   has_paper_trail
 
   belongs_to :user

--- a/app/models/collection_admin.rb
+++ b/app/models/collection_admin.rb
@@ -9,7 +9,7 @@
 # -------------------- | ------------------ | ---------------------------
 # **`id`**             | `integer`          | `not null, primary key`
 # **`collection_id`**  | `integer`          | `not null`
-# **`user_id`**        | `integer`          | `not null`
+# **`user_id`**        | `bigint`           | `not null`
 #
 # ### Indexes
 #
@@ -20,6 +20,13 @@
 #     * **`user_id`**
 # * `index_collection_admins_on_user_id`:
 #     * **`user_id`**
+#
+# ### Foreign Keys
+#
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`collection_id => collections.id`**
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`user_id => users.id`**
 #
 
 class CollectionAdmin < ApplicationRecord

--- a/app/models/collection_user.rb
+++ b/app/models/collection_user.rb
@@ -1,0 +1,41 @@
+# ## Schema Information
+#
+# Table name: `collection_users`
+# Database name: `primary`
+#
+# ### Columns
+#
+# Name                 | Type               | Attributes
+# -------------------- | ------------------ | ---------------------------
+# **`id`**             | `integer`          | `not null, primary key`
+# **`collection_id`**  | `integer`          | `not null`
+# **`user_id`**        | `integer`          | `not null`
+#
+# ### Indexes
+#
+# * `index_collection_users_on_collection_id`:
+#     * **`collection_id`**
+# * `index_collection_users_on_collection_id_and_user_id` (_unique_):
+#     * **`collection_id`**
+#     * **`user_id`**
+# * `index_collection_users_on_user_id`:
+#     * **`user_id`**
+#
+
+class CollectionUser < ApplicationRecord
+  has_paper_trail
+
+  belongs_to :user
+  belongs_to :collection
+
+  validates :user_id, presence: true
+  validates :collection_id, uniqueness: { scope: [:collection_id, :user_id] }
+
+  after_commit :reindex_collection_essences
+
+  private
+
+  def reindex_collection_essences
+    collection.essences.reindex(mode: :async)
+  end
+end

--- a/app/models/collection_user.rb
+++ b/app/models/collection_user.rb
@@ -23,6 +23,8 @@
 #
 
 class CollectionUser < ApplicationRecord
+  include RejectsContactGrants
+
   has_paper_trail
 
   belongs_to :user

--- a/app/models/collection_user.rb
+++ b/app/models/collection_user.rb
@@ -9,7 +9,7 @@
 # -------------------- | ------------------ | ---------------------------
 # **`id`**             | `integer`          | `not null, primary key`
 # **`collection_id`**  | `integer`          | `not null`
-# **`user_id`**        | `integer`          | `not null`
+# **`user_id`**        | `bigint`           | `not null`
 #
 # ### Indexes
 #
@@ -20,6 +20,13 @@
 #     * **`user_id`**
 # * `index_collection_users_on_user_id`:
 #     * **`user_id`**
+#
+# ### Foreign Keys
+#
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`collection_id => collections.id`**
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`user_id => users.id`**
 #
 
 class CollectionUser < ApplicationRecord

--- a/app/models/concerns/rejects_contact_grants.rb
+++ b/app/models/concerns/rejects_contact_grants.rb
@@ -1,0 +1,18 @@
+# Shared guard for the four permission grant models (collection/item read-only and edit grants).
+# Contact-only users exist purely so that work can be attributed to them (collector/operator);
+# they never log in, so they must never hold an access grant.
+module RejectsContactGrants
+  extend ActiveSupport::Concern
+
+  included do
+    validate :grantee_must_not_be_contact_only
+  end
+
+  private
+
+  def grantee_must_not_be_contact_only
+    return unless user&.contact_only?
+
+    errors.add(:user, 'cannot be a contact-only user; contacts can be attributed but not granted access')
+  end
+end

--- a/app/models/essence.rb
+++ b/app/models/essence.rb
@@ -69,7 +69,7 @@ class Essence < ApplicationRecord
       :collection, :collector, :operator,
       :content_languages, :countries,
       :item_admins, :item_users,
-      { collection: :collection_admins }
+      { collection: %i[collection_admins collection_users] }
     ])
   }
 
@@ -220,6 +220,7 @@ class Essence < ApplicationRecord
       collector_id: item.collector_id,
       operator_id: item.operator_id,
       collection_admin_ids: item.collection.collection_admins.map(&:user_id).uniq,
+      collection_user_ids: item.collection.collection_users.map(&:user_id).uniq,
 
       originated_on: item.originated_on,
       created_at: created_at&.to_date,
@@ -228,7 +229,7 @@ class Essence < ApplicationRecord
   end
 
   def self.search_user_fields
-    %i[admin_ids user_ids collection_admin_ids]
+    %i[admin_ids user_ids collection_admin_ids collection_user_ids]
   end
 
   def self.search_agg_fields
@@ -249,7 +250,7 @@ class Essence < ApplicationRecord
 
   def self.search_includes
     [{ item: [:collection, :collector, :content_languages, :countries, :item_admins, :item_users,
-              { collection: :collection_admins }] }, :entity]
+              { collection: %i[collection_admins collection_users] }] }, :entity]
   end
 
   def self.ransackable_attributes(_ = nil)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -275,7 +275,7 @@ class Item < ApplicationRecord
   end
 
   def self.search_user_fields
-    %i[admin_ids user_ids]
+    %i[admin_ids user_ids collection_user_ids]
   end
 
   def self.search_agg_fields
@@ -313,9 +313,10 @@ class Item < ApplicationRecord
   scope :search_import,
         lambda {
           includes(:users, :content_languages, :subject_languages, :countries, :university, :data_types, :data_categories, :discourse_type,
-                   :essences, :collection, :collector, :operator,
+                   :essences, :collector, :operator,
                    :item_admins, :item_agents, :item_users,
-                   :access_condition
+                   :access_condition,
+                   collection: :collection_users
                   )
         }
 
@@ -382,6 +383,7 @@ class Item < ApplicationRecord
       admin_ids: item_admins.map(&:user_id).uniq,
       agent_ids: item_agents.map(&:user_id).uniq,
       user_ids: item_users.map(&:user_id).uniq,
+      collection_user_ids: collection.collection_users.map(&:user_id).uniq,
       originated_on:,
       metadata_exportable:,
       born_digital:,

--- a/app/models/item_admin.rb
+++ b/app/models/item_admin.rb
@@ -19,6 +19,8 @@
 #
 
 class ItemAdmin < ApplicationRecord
+  include RejectsContactGrants
+
   has_paper_trail
 
   belongs_to :user

--- a/app/models/item_admin.rb
+++ b/app/models/item_admin.rb
@@ -9,13 +9,22 @@
 # -------------- | ------------------ | ---------------------------
 # **`id`**       | `integer`          | `not null, primary key`
 # **`item_id`**  | `integer`          | `not null`
-# **`user_id`**  | `integer`          | `not null`
+# **`user_id`**  | `bigint`           | `not null`
 #
 # ### Indexes
 #
 # * `index_item_admins_on_item_id_and_user_id` (_unique_):
 #     * **`item_id`**
 #     * **`user_id`**
+# * `index_item_admins_on_user_id`:
+#     * **`user_id`**
+#
+# ### Foreign Keys
+#
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`item_id => items.id`**
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`user_id => users.id`**
 #
 
 class ItemAdmin < ApplicationRecord

--- a/app/models/item_user.rb
+++ b/app/models/item_user.rb
@@ -19,6 +19,8 @@
 #
 
 class ItemUser < ApplicationRecord
+  include RejectsContactGrants
+
   has_paper_trail
 
   belongs_to :user

--- a/app/models/item_user.rb
+++ b/app/models/item_user.rb
@@ -9,13 +9,22 @@
 # -------------- | ------------------ | ---------------------------
 # **`id`**       | `integer`          | `not null, primary key`
 # **`item_id`**  | `integer`          | `not null`
-# **`user_id`**  | `integer`          | `not null`
+# **`user_id`**  | `bigint`           | `not null`
 #
 # ### Indexes
 #
 # * `index_item_users_on_item_id_and_user_id` (_unique_):
 #     * **`item_id`**
 #     * **`user_id`**
+# * `index_item_users_on_user_id`:
+#     * **`user_id`**
+#
+# ### Foreign Keys
+#
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`item_id => items.id`**
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`user_id => users.id`**
 #
 
 class ItemUser < ApplicationRecord

--- a/app/services/collection_destruction_service.rb
+++ b/app/services/collection_destruction_service.rb
@@ -4,9 +4,13 @@ class CollectionDestructionService
     essence_ids = essences.map(&:id)
     item_ids = collection.items.map(&:id)
 
-    # delete_all is efficient but skips ActiveRecord callbacks, so the `has_one :entity, dependent: :destroy`
-    # cleanup on Item/Essence never fires. Remove the denormalised entity rows ourselves to avoid orphans.
+    # delete_all is efficient but skips ActiveRecord callbacks, so the `dependent: :destroy`
+    # cleanup on Item/Essence never fires. Remove the dependent rows ourselves to avoid orphans:
+    # the denormalised entity rows and the items' edit/read-only membership grants.
     Essence.where(id: essence_ids).delete_all
+    ItemAdmin.where(item_id: item_ids).delete_all
+    ItemUser.where(item_id: item_ids).delete_all
+    CollectionUser.where(collection_id: collection.id).delete_all
     deleted_items_count = Item.where(collection_id: collection.id).delete_all
     Entity.where(entity_type: 'Essence', entity_id: essence_ids).delete_all
     Entity.where(entity_type: 'Item', entity_id: item_ids).delete_all

--- a/app/services/permissions/collector_backfill.rb
+++ b/app/services/permissions/collector_backfill.rb
@@ -1,0 +1,62 @@
+module Permissions
+  # One-off deploy backfill that preserves access for collectors who would otherwise be locked
+  # out once attribution (collector/operator) stops conferring rights in the Phase 1 rework.
+  #
+  # Targets only *real, active* collectors — `contact_only = false` and a non-null last sign-in.
+  # Contacts and never-logged-in users are skipped; operators get nothing.
+  #
+  #   * collection read-only (collection_users) for each collection's collector
+  #   * item read-only (item_users) for items whose collector differs from their collection's
+  #     collector (the common case is already covered by the collection grant)
+  #
+  # Idempotent: only rows not already present are inserted, and the unique indexes guard against
+  # any racing duplicate. Inserts go through `insert_all`, which bypasses model callbacks and
+  # paper_trail; the whole run is additionally wrapped in `Searchkick.callbacks(false)` so no
+  # per-row reindex fires. The bulk reindex is a separate, explicit deploy step.
+  class CollectorBackfill
+    def call
+      Searchkick.callbacks(false) do
+        {
+          collection_read_only: backfill(CollectionUser, :collection_id, collection_candidates),
+          item_read_only: backfill(ItemUser, :item_id, item_candidates)
+        }
+      end
+    end
+
+    private
+
+    # Real users who have actually logged in. Anything else (contacts, never-signed-in) is skipped.
+    def real_user_ids
+      User.where(contact_only: false).where.not(last_sign_in_at: nil).select(:id)
+    end
+
+    def collection_candidates
+      Collection.where(collector_id: real_user_ids)
+                .pluck(:id, :collector_id)
+                .map { |collection_id, user_id| { collection_id:, user_id: } }
+    end
+
+    def item_candidates
+      Item.joins(:collection)
+          .where(collector_id: real_user_ids)
+          .where('items.collector_id != collections.collector_id')
+          .pluck(:id, :collector_id)
+          .map { |item_id, user_id| { item_id:, user_id: } }
+    end
+
+    # Inserts only the candidate rows that don't already exist, so re-running grants nothing new.
+    # Returns the number of rows actually inserted.
+    def backfill(model, owner_key, candidates)
+      return 0 if candidates.empty?
+
+      existing = model.where(owner_key => candidates.map { |row| row[owner_key] })
+                      .pluck(owner_key, :user_id)
+                      .to_set
+      fresh = candidates.reject { |row| existing.include?([row[owner_key], row[:user_id]]) }
+      return 0 if fresh.empty?
+
+      model.insert_all(fresh)
+      fresh.size
+    end
+  end
+end

--- a/app/services/permissions/contact_grant_auditor.rb
+++ b/app/services/permissions/contact_grant_auditor.rb
@@ -1,0 +1,74 @@
+module Permissions
+  # Audits the four permission grant tables for rows that violate the
+  # attribution-vs-access separation introduced in the Phase 1 permissions rework:
+  #
+  #   * contamination — grants whose user is contact-only. Contacts exist purely so
+  #     that work can be attributed to them; they never log in and must never hold a grant.
+  #   * orphans       — grants whose item/collection has been deleted. These are dead
+  #     data-integrity debt left behind by historical bulk-delete paths.
+  #
+  # `report` is read-only and returns labelled counts for both kinds in separate sections.
+  # `cleanup` deletes the contaminated rows. `prune_orphans` is a *separately-invokable*
+  # step that deletes the orphan rows — it is deliberately never called by `cleanup`, so the
+  # two clean-ups are never conflated.
+  #
+  # Every query is expressed as a foreign-key subquery (no joins), so each relation is safe to
+  # both `count` and `delete_all`. The mutating methods rely on `delete_all` and so skip the
+  # models' reindex callbacks; the rake wrappers additionally run inside
+  # `Searchkick.callbacks(false)` so the bulk reindex stays an explicit, separate deploy step.
+  class ContactGrantAuditor
+    # Ordered so reports read collection-then-item, edit-then-read-only.
+    GRANTS = {
+      collection_edit: { model: CollectionAdmin, owner: Collection, foreign_key: :collection_id },
+      collection_read_only: { model: CollectionUser, owner: Collection, foreign_key: :collection_id },
+      item_edit: { model: ItemAdmin, owner: Item, foreign_key: :item_id },
+      item_read_only: { model: ItemUser, owner: Item, foreign_key: :item_id }
+    }.freeze
+
+    def report
+      { contamination: contamination_counts, orphans: orphan_counts }
+    end
+
+    def contamination_counts
+      counts { |config| contaminated(config) }
+    end
+
+    def orphan_counts
+      counts { |config| orphaned(config) }
+    end
+
+    # Deletes grant rows pointing at contact-only users. Returns per-table deleted counts.
+    def cleanup
+      delete_each { |config| contaminated(config) }
+    end
+
+    # Separately-invokable: deletes grant rows pointing at deleted items/collections.
+    # Intentionally not called by #cleanup so orphan pruning is never conflated with the
+    # contact clean-up. Returns per-table deleted counts.
+    def prune_orphans
+      delete_each { |config| orphaned(config) }
+    end
+
+    private
+
+    def contaminated(config)
+      config[:model].where(user_id: User.where(contact_only: true).select(:id))
+    end
+
+    def orphaned(config)
+      config[:model].where.not(config[:foreign_key] => config[:owner].select(:id))
+    end
+
+    def counts
+      tallied(GRANTS.transform_values { |config| yield(config).count })
+    end
+
+    def delete_each
+      tallied(GRANTS.transform_values { |config| yield(config).delete_all })
+    end
+
+    def tallied(counts)
+      counts.merge(total: counts.values.sum)
+    end
+  end
+end

--- a/app/views/collections/_form.html.haml
+++ b/app/views/collections/_form.html.haml
@@ -127,6 +127,11 @@
             %small Append
             = f.check_box :bulk_edit_append_admin_ids
 
+      - if current_user&.admin?
+        %tr
+          %th= f.label :user_ids, 'Read-only access'
+          %td= f.user_select :user_ids, placeholder: 'Choose a user...', multiple: true
+
       %tr
         %th= f.label :access_condition, 'Data access conditions'
         %td= f.access_condition_select :access_condition_id, placeholder: 'Choose an access condition...'

--- a/app/views/collections/_form.html.haml
+++ b/app/views/collections/_form.html.haml
@@ -122,7 +122,7 @@
       - if current_user&.admin?
         %tr
           %th= f.label :admin_ids, 'Edit access'
-          %td= f.user_select :admin_ids, placeholder: 'Choose a user...', multiple: true
+          %td= f.user_select :admin_ids, placeholder: 'Choose a user...', multiple: true, exclude_contacts: true
           - if params[:action] == 'bulk_edit'
             %td.append
               %small Append
@@ -130,7 +130,7 @@
 
         %tr
           %th= f.label :user_ids, 'Read-only access'
-          %td= f.user_select :user_ids, placeholder: 'Choose a user...', multiple: true
+          %td= f.user_select :user_ids, placeholder: 'Choose a user...', multiple: true, exclude_contacts: true
 
       %tr
         %th= f.label :access_condition, 'Data access conditions'

--- a/app/views/collections/_form.html.haml
+++ b/app/views/collections/_form.html.haml
@@ -119,15 +119,15 @@
   %fieldset
     %legend Access Information
     %table.form
-      %tr
-        %th= f.label :admin_ids, 'Edit access'
-        %td= f.user_select :admin_ids, placeholder: 'Choose a user...', multiple: true
-        - if params[:action] == 'bulk_edit'
-          %td.append
-            %small Append
-            = f.check_box :bulk_edit_append_admin_ids
-
       - if current_user&.admin?
+        %tr
+          %th= f.label :admin_ids, 'Edit access'
+          %td= f.user_select :admin_ids, placeholder: 'Choose a user...', multiple: true
+          - if params[:action] == 'bulk_edit'
+            %td.append
+              %small Append
+              = f.check_box :bulk_edit_append_admin_ids
+
         %tr
           %th= f.label :user_ids, 'Read-only access'
           %td= f.user_select :user_ids, placeholder: 'Choose a user...', multiple: true

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -297,7 +297,7 @@
       - if current_user&.admin?
         %tr
           %th= f.label :admin_ids, 'Edit access'
-          %td= f.user_select :admin_ids, placeholder: 'Choose a user...', multiple: true
+          %td= f.user_select :admin_ids, placeholder: 'Choose a user...', multiple: true, exclude_contacts: true
           - if params[:action] == 'bulk_edit'
             %td.append
               %small Append
@@ -305,7 +305,7 @@
 
         %tr
           %th= f.label :user_ids, 'Read/Download access'
-          %td= f.user_select :user_ids, placeholder: 'Choose a user...', multiple: true
+          %td= f.user_select :user_ids, placeholder: 'Choose a user...', multiple: true, exclude_contacts: true
           - if params[:action] == 'bulk_edit'
             %td.append
               %small Append

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -294,21 +294,22 @@
   %fieldset
     %legend Admin information
     %table.form
-      %tr
-        %th= f.label :admin_ids, 'Edit access'
-        %td= f.user_select :admin_ids, placeholder: 'Choose a user...', multiple: true
-        - if params[:action] == 'bulk_edit'
-          %td.append
-            %small Append
-            = f.check_box :bulk_edit_append_admin_ids
+      - if current_user&.admin?
+        %tr
+          %th= f.label :admin_ids, 'Edit access'
+          %td= f.user_select :admin_ids, placeholder: 'Choose a user...', multiple: true
+          - if params[:action] == 'bulk_edit'
+            %td.append
+              %small Append
+              = f.check_box :bulk_edit_append_admin_ids
 
-      %tr
-        %th= f.label :user_ids, 'Read/Download access'
-        %td= f.user_select :user_ids, placeholder: 'Choose a user...', multiple: true
-        - if params[:action] == 'bulk_edit'
-          %td.append
-            %small Append
-            = f.check_box :bulk_edit_append_user_ids
+        %tr
+          %th= f.label :user_ids, 'Read/Download access'
+          %td= f.user_select :user_ids, placeholder: 'Choose a user...', multiple: true
+          - if params[:action] == 'bulk_edit'
+            %td.append
+              %small Append
+              = f.check_box :bulk_edit_append_user_ids
 
       %tr
         %th= f.label :access_condition, 'Data access conditions'

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "24.12.0",
-    "aws-cdk": "2.1126.0",
+    "aws-cdk": "2.1127.0",
     "cdk-agc": "^1.14.0",
     "jest": "^30.3.0",
     "ts-jest": "^29.4.9",
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "2.259.0",
-    "cdk-nag": "^3.0.0",
+    "cdk-nag": "^3.0.1",
     "constructs": "^10.6.0",
     "source-map-support": "^0.5.21"
   }

--- a/db/migrate/20260617000001_create_collection_users.rb
+++ b/db/migrate/20260617000001_create_collection_users.rb
@@ -1,0 +1,12 @@
+class CreateCollectionUsers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :collection_users, id: :integer do |t|
+      t.integer :collection_id, null: false
+      t.integer :user_id, null: false
+    end
+
+    add_index :collection_users, :collection_id
+    add_index :collection_users, :user_id
+    add_index :collection_users, %i[collection_id user_id], unique: true, name: 'index_collection_users_on_collection_id_and_user_id'
+  end
+end

--- a/db/migrate/20260617000002_harden_membership_tables_with_cascading_foreign_keys.rb
+++ b/db/migrate/20260617000002_harden_membership_tables_with_cascading_foreign_keys.rb
@@ -1,0 +1,57 @@
+class HardenMembershipTablesWithCascadingForeignKeys < ActiveRecord::Migration[8.1]
+  MEMBERSHIP_TABLES = %i[collection_admins collection_users item_admins item_users].freeze
+
+  # item_admins/item_users only index user_id via the composite (item_id, user_id)
+  # index, which can't back a user_id foreign key. Add a standalone index with a
+  # conventional name so MySQL doesn't auto-create one named after the constraint.
+  USER_ID_INDEX_TABLES = %i[item_admins item_users].freeze
+
+  # Each membership/grant table and the parent tables its columns reference.
+  MEMBERSHIP_FOREIGN_KEYS = {
+    collection_admins: { collections: :collection_id, users: :user_id },
+    collection_users: { collections: :collection_id, users: :user_id },
+    item_admins: { items: :item_id, users: :user_id },
+    item_users: { items: :item_id, users: :user_id }
+  }.freeze
+
+  def up
+    # users.id is a bigint, so the referencing user_id columns must be widened to
+    # match before a foreign key can be added.
+    MEMBERSHIP_TABLES.each do |table|
+      change_column table, :user_id, :bigint, null: false
+    end
+
+    USER_ID_INDEX_TABLES.each do |table|
+      add_index table, :user_id, name: "index_#{table}_on_user_id"
+    end
+
+    MEMBERSHIP_FOREIGN_KEYS.each do |table, references|
+      references.each do |parent_table, column|
+        # Remove orphan rows so the constraint can be added.
+        execute(<<~SQL.squish)
+          DELETE child FROM #{table} child
+          LEFT JOIN #{parent_table} parent ON child.#{column} = parent.id
+          WHERE parent.id IS NULL
+        SQL
+
+        add_foreign_key table, parent_table, column: column, on_delete: :cascade
+      end
+    end
+  end
+
+  def down
+    MEMBERSHIP_FOREIGN_KEYS.each do |table, references|
+      references.each do |parent_table, column|
+        remove_foreign_key table, parent_table, column: column
+      end
+    end
+
+    USER_ID_INDEX_TABLES.each do |table|
+      remove_index table, name: "index_#{table}_on_user_id"
+    end
+
+    MEMBERSHIP_TABLES.each do |table|
+      change_column table, :user_id, :integer, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_27_000002) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_17_000001) do
   create_table "access_conditions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.string "name"
@@ -61,6 +61,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_000002) do
     t.integer "collection_id"
     t.integer "language_id"
     t.index ["collection_id", "language_id"], name: "index_collection_languages_on_collection_id_and_language_id", unique: true
+  end
+
+  create_table "collection_users", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "collection_id", null: false
+    t.integer "user_id", null: false
+    t.index ["collection_id", "user_id"], name: "index_collection_users_on_collection_id_and_user_id", unique: true
+    t.index ["collection_id"], name: "index_collection_users_on_collection_id"
+    t.index ["user_id"], name: "index_collection_users_on_user_id"
   end
 
   create_table "collections", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_17_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_17_000002) do
   create_table "access_conditions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.string "name"
@@ -45,7 +45,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_17_000001) do
 
   create_table "collection_admins", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "collection_id", null: false
-    t.integer "user_id", null: false
+    t.bigint "user_id", null: false
     t.index ["collection_id", "user_id"], name: "index_collection_admins_on_collection_id_and_user_id", unique: true
     t.index ["collection_id"], name: "index_collection_admins_on_collection_id"
     t.index ["user_id"], name: "index_collection_admins_on_user_id"
@@ -65,7 +65,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_17_000001) do
 
   create_table "collection_users", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "collection_id", null: false
-    t.integer "user_id", null: false
+    t.bigint "user_id", null: false
     t.index ["collection_id", "user_id"], name: "index_collection_users_on_collection_id_and_user_id", unique: true
     t.index ["collection_id"], name: "index_collection_users_on_collection_id"
     t.index ["user_id"], name: "index_collection_users_on_user_id"
@@ -249,8 +249,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_17_000001) do
 
   create_table "item_admins", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "item_id", null: false
-    t.integer "user_id", null: false
+    t.bigint "user_id", null: false
     t.index ["item_id", "user_id"], name: "index_item_admins_on_item_id_and_user_id", unique: true
+    t.index ["user_id"], name: "index_item_admins_on_user_id"
   end
 
   create_table "item_agents", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -293,8 +294,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_17_000001) do
 
   create_table "item_users", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "item_id", null: false
-    t.integer "user_id", null: false
+    t.bigint "user_id", null: false
     t.index ["item_id", "user_id"], name: "index_item_users_on_item_id_and_user_id", unique: true
+    t.index ["user_id"], name: "index_item_users_on_user_id"
   end
 
   create_table "items", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -501,9 +503,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_17_000001) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  add_foreign_key "collection_admins", "collections", on_delete: :cascade
+  add_foreign_key "collection_admins", "users", on_delete: :cascade
+  add_foreign_key "collection_users", "collections", on_delete: :cascade
+  add_foreign_key "collection_users", "users", on_delete: :cascade
   add_foreign_key "essence_annotations", "essences", column: "annotation_essence_id", on_delete: :cascade
   add_foreign_key "essence_annotations", "essences", column: "target_essence_id", on_delete: :cascade
   add_foreign_key "essences", "users", column: "created_by_id"
+  add_foreign_key "item_admins", "items", on_delete: :cascade
+  add_foreign_key "item_admins", "users", on_delete: :cascade
+  add_foreign_key "item_users", "items", on_delete: :cascade
+  add_foreign_key "item_users", "users", on_delete: :cascade
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_grants", "users", column: "resource_owner_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"

--- a/docs/runbooks/permissions-phase1-deploy.md
+++ b/docs/runbooks/permissions-phase1-deploy.md
@@ -1,0 +1,187 @@
+# Runbook — Permissions Phase 1 production deploy
+
+Tracking issue: [#1135](https://github.com/paradisec-archive/nabu/issues/1135) ·
+Parent: [#1127](https://github.com/paradisec-archive/nabu/issues/1127)
+
+Coordinates the single production deploy for the Phase 1 permissions rework
+(separating *attribution* from *access*). The user base is small and a brief
+lockout window is acceptable, but **the steps must run in order** and the
+contamination report **must be reviewed by a human** before any cleanup runs.
+
+This is a `ready-for-human` task: every step below runs against production and
+must be executed by a person with `nabu-prod` AWS credentials.
+
+## What ships in this deploy
+
+All of the following are already merged on the deploy branch and ship together
+in a single `bin/release prod`:
+
+| Issue | Change |
+| ----- | ------ |
+| #1128 | Ability: attribution (collector/operator) no longer confers rights |
+| #1129 | Collection read-only grant via new `collection_users` membership |
+| #1130 | Admin-only grant assignment on collection and item forms |
+| #1131 | Contact-grant invariant (reject contact-only users from grants) |
+| #1132 | `Permissions::CollectorBackfill` service + `permissions:collector_backfill` |
+| #1133 | `Permissions::ContactGrantAuditor` + `permissions:contact_grants_*` tasks |
+| #1134 | Collection deletion cleans up membership rows and grants |
+| #1136 | DB-level `on_delete: :cascade` FKs on membership tables |
+
+### Deploy-model caveat — migrations are NOT applied automatically
+
+`bin/docker-entrypoint` is the `ENTRYPOINT` for the production container, but its
+`db:prepare` branch only fires when the launch command ends with exactly
+`./bin/rails server`. The production `CMD`
+(`./bin/thrust ./bin/rails server --log-to-stdout -b 0.0.0.0`) ends in
+`-b 0.0.0.0`, so the guard does **not** match and **no migration runs on boot**.
+
+Migrations must therefore be run **explicitly** after deploy:
+
+```bash
+bin/aws/ecs_rake app db:migrate
+```
+
+(The README mentions `deploy:migrate`, but no such task is defined in this repo —
+use `db:migrate`.)
+
+This has an ordering consequence: `bin/release prod` rolls the new image into the
+ECS service *before* you can migrate, so for a short window the new
+Ability/membership code runs against the old schema (no `collection_users`).
+Migrate as the very next step, immediately after the service is up. The banner
+covers this window.
+
+### The lockout window
+
+Once #1128 is live, attribution stops conferring rights. Real collectors who
+relied on being a collection/item's collector lose access until
+`permissions:collector_backfill` (#1132) inserts their read-only grants. The
+backfill needs `collection_users`, so it can only run after `db:migrate`. The gap
+between deploy and a completed backfill is the acceptable lockout window — keep it
+short by running migrate then backfill immediately once the deploy is healthy.
+
+## Pre-flight
+
+- [ ] Confirm the deploy branch is merged to `main` and CI is green.
+- [ ] Confirm you can authenticate: `AWS_PROFILE=nabu-prod aws sts get-caller-identity`.
+- [ ] Take/verify a recent production DB backup (`AWS_PROFILE=nabu-prod bin/aws/db_backup`).
+- [ ] Dry-run the figures on staging if possible (deploy to stage, run the
+      backfill and the contamination report there first).
+
+## Steps
+
+All rake tasks run on the production ECS task via `bin/aws/ecs_rake app <task>`.
+For interactive work use `bin/aws/ecs_shell`.
+
+### 1. Raise the announcement banner
+
+The banner is data-driven via the `AdminMessage` model (served to the `oni`
+frontend through the API, shown while `start_at <= now <= finish_at`). Create
+one in ActiveAdmin (Admin → Admin Messages) **before** deploying, e.g.:
+
+> PARADISEC is performing a brief permissions upgrade. Access may be
+> intermittent for a short period. Thanks for your patience.
+
+Set `start_at` to now and `finish_at` to a safe upper bound (e.g. +2 hours).
+
+- [ ] Banner created and visible on the catalogue front end.
+
+### 2. Deploy the code
+
+```bash
+bin/release prod
+```
+
+This ships the new image and rolls the ECS service. Migrations do **not** run
+automatically (see caveat above).
+
+- [ ] Deploy completed; service healthy.
+
+### 2a. Apply the migration — *immediately after the service is up*
+
+```bash
+bin/aws/ecs_rake app db:migrate
+```
+
+- [ ] Migration applied; `collection_users` present in production
+      (`bin/aws/ecs_rake app db:version`, or check via `bin/aws/ecs_shell`).
+
+### 3. Run the collector backfill — *immediately after migrate*
+
+```bash
+bin/aws/ecs_rake app permissions:collector_backfill
+```
+
+Idempotent; targets only real, logged-in collectors (`contact_only = false`,
+non-null `last_sign_in_at`); suppresses reindex callbacks. **Record the printed
+counts** (collection read-only / item read-only inserted) in the issue and
+confirm they match the expected production divergence figures.
+
+- [ ] Backfill run; inserted counts recorded and confirmed.
+
+### 4. Contamination report → **human review** → cleanup
+
+First, report only (read-only, no mutation):
+
+```bash
+bin/aws/ecs_rake app permissions:contact_grants_report
+```
+
+- [ ] **A human reviews the contamination and orphan counts before proceeding.**
+      Do not run cleanup until the figures look sane.
+
+Then delete contaminated grants (grants pointing at contact-only users):
+
+```bash
+bin/aws/ecs_rake app permissions:contact_grants_cleanup
+```
+
+Finally, prune orphan grants (grants pointing at deleted items/collections) as a
+**separate, explicit, confirmed step**:
+
+```bash
+bin/aws/ecs_rake app permissions:contact_grants_cleanup PRUNE_ORPHANS=true
+```
+
+- [ ] Report reviewed by a human.
+- [ ] Contact cleanup run; deleted counts recorded.
+- [ ] Orphan prune run as its own confirmed step; deleted counts recorded.
+
+### 5. Single explicit bulk reindex
+
+The backfill and cleanup steps suppress Searchkick callbacks, so search must be
+rebuilt once, explicitly:
+
+```bash
+bin/aws/ecs_rake app search:reindex
+```
+
+Reindexes Collection, Item, and Essence (size-aware batching for Essence).
+
+- [ ] Bulk reindex of collections, items, essences completed.
+
+### 6. Lower the announcement banner
+
+Expire the `AdminMessage` (set `finish_at` to now, or delete the record) in
+ActiveAdmin.
+
+- [ ] Banner removed.
+
+## Post-deploy verification (spot-check)
+
+- [ ] A guest (not logged in) can read a public collection/item.
+- [ ] A guest can download an Open-access essence.
+- [ ] A real collector who had attribution-derived access still has read access
+      to their collection/items (confirms the backfill).
+- [ ] An admin retains full access, including preservation masters.
+- [ ] A contact-only user holds no grants and cannot access restricted material.
+
+## Rollback notes
+
+- The migration is additive (`collection_users` table); it does not drop or
+  rewrite existing data, so a code rollback can leave the table in place.
+- `collector_backfill` is idempotent and only inserts; re-running is safe.
+- `contact_grants_cleanup` and the orphan prune are destructive `delete_all`s —
+  rely on the pre-flight DB backup if rows must be restored.
+- All grant tables are paper-trail tracked except the bulk insert/delete paths
+  used here (which deliberately bypass callbacks for performance); the DB backup
+  is the source of truth for recovery.

--- a/lib/tasks/permissions.rake
+++ b/lib/tasks/permissions.rake
@@ -1,0 +1,40 @@
+namespace :permissions do
+  LABELS = {
+    collection_edit: 'collection edit (collection_admins)',
+    collection_read_only: 'collection read-only (collection_users)',
+    item_edit: 'item edit (item_admins)',
+    item_read_only: 'item read-only (item_users)'
+  }.freeze
+
+  print_section = lambda do |title, counts|
+    puts title
+    LABELS.each { |key, label| puts format('  %-44s %d', label, counts.fetch(key)) }
+    puts format('  %-44s %d', 'total', counts.fetch(:total))
+  end
+
+  desc 'Report grant rows pointing at contact-only users (contamination) or deleted items/collections (orphans)'
+  task contact_grants_report: :environment do
+    report = Searchkick.callbacks(false) { Permissions::ContactGrantAuditor.new.report }
+
+    print_section.call('Contamination (grants pointing at contact-only users):', report[:contamination])
+    puts
+    print_section.call('Orphans (grants pointing at deleted items/collections):', report[:orphans])
+  end
+
+  desc 'Delete grant rows pointing at contact-only users. Set PRUNE_ORPHANS=true to also prune orphan rows.'
+  task contact_grants_cleanup: :environment do
+    auditor = Permissions::ContactGrantAuditor.new
+
+    Searchkick.callbacks(false) do
+      print_section.call('Deleted contaminated grants (contact-only users):', auditor.cleanup)
+
+      if ENV['PRUNE_ORPHANS'] == 'true'
+        puts
+        print_section.call('Deleted orphan grants (deleted items/collections):', auditor.prune_orphans)
+      else
+        puts
+        puts 'Orphan rows left untouched. Re-run with PRUNE_ORPHANS=true to prune them.'
+      end
+    end
+  end
+end

--- a/lib/tasks/permissions.rake
+++ b/lib/tasks/permissions.rake
@@ -37,4 +37,13 @@ namespace :permissions do
       end
     end
   end
+
+  desc 'Backfill read-only grants for real, logged-in collectors (idempotent; no reindex)'
+  task collector_backfill: :environment do
+    inserted = Permissions::CollectorBackfill.new.call
+
+    puts 'Inserted read-only grants for real, logged-in collectors:'
+    puts format('  %-44s %d', 'collection read-only (collection_users)', inserted.fetch(:collection_read_only))
+    puts format('  %-44s %d', 'item read-only (item_users)', inserted.fetch(:item_read_only))
+  end
 end

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@activeadmin/activeadmin": "4.0.0-beta20",
     "@googlemaps/js-api-loader": "^2.1.1",
     "@googlemaps/markerclusterer": "^2.6.2",
-    "@sentry/browser": "^10.57.0",
+    "@sentry/browser": "^10.58.0",
     "choices.js": "^11.2.3",
     "sass": "^1.101.0",
     "tailwindcss": "^4.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^2.6.2
         version: 2.6.2
       '@sentry/browser':
-        specifier: ^10.57.0
-        version: 10.57.0
+        specifier: ^10.58.0
+        version: 10.58.0
       choices.js:
         specifier: ^11.2.3
         version: 11.2.3
@@ -46,8 +46,8 @@ importers:
         specifier: 2.259.0
         version: 2.259.0(constructs@10.6.0)
       cdk-nag:
-        specifier: ^3.0.0
-        version: 3.0.0(aws-cdk-lib@2.259.0(constructs@10.6.0))(constructs@10.6.0)
+        specifier: ^3.0.1
+        version: 3.0.1(aws-cdk-lib@2.259.0(constructs@10.6.0))(constructs@10.6.0)
       constructs:
         specifier: ^10.6.0
         version: 10.6.0
@@ -62,8 +62,8 @@ importers:
         specifier: 24.12.0
         version: 24.12.0
       aws-cdk:
-        specifier: 2.1126.0
-        version: 2.1126.0
+        specifier: 2.1127.0
+        version: 2.1127.0
       cdk-agc:
         specifier: ^1.14.0
         version: 1.14.0
@@ -767,28 +767,28 @@ packages:
       rollup:
         optional: true
 
-  '@sentry-internal/browser-utils@10.57.0':
-    resolution: {integrity: sha512-tXObp954rMTSYKlbftjVXHtNl4t/6ssks3jkqyzmKb+PDPWzabGQO7sWwqVuTjT8Kx/8A3FmriS1bGmqxiJy3A==}
+  '@sentry/browser-utils@10.58.0':
+    resolution: {integrity: sha512-TzXrhZq3Llj6qPSv0ZVG5N5c7C6qNN/aRKJXhq2LombJrLwiQrWdgizp7zdHA0FGlZ7F5YpyRA2JIpkhvrFqYA==}
     engines: {node: '>=18'}
 
-  '@sentry-internal/feedback@10.57.0':
-    resolution: {integrity: sha512-ZcF4QhkqGX3iiQSXB2N0N3Awp+j5iqnDRu6PA/qyLFrWqH5ZiiAAgu59OLD9E6XAdg6iFtLYw19MAMZVK8qNOQ==}
+  '@sentry/browser@10.58.0':
+    resolution: {integrity: sha512-Syf6h6HDwC15fk86+/0ql8ebwwJFw2wp+lvOX9GfLTJVOqrSILCrtLKNI+f4v/3w8mzImsv9ttJGGbUugLNvcA==}
     engines: {node: '>=18'}
 
-  '@sentry-internal/replay-canvas@10.57.0':
-    resolution: {integrity: sha512-zsfa4JcfV0AEc9YhNxNabd5lSZL2Av84saAyexGAqcHs+67m9Gd0cGStOzMb/nCl7UAtmdP0aI+G7a3rcxxN/A==}
+  '@sentry/core@10.58.0':
+    resolution: {integrity: sha512-bkIbh2c6dzwhrWn/FGWu7j8hf6TAat2XxpkGM91LiN09fLYUXIMwcohVsXqze5l2cq35TnvqmSROAbRNr27GVw==}
     engines: {node: '>=18'}
 
-  '@sentry-internal/replay@10.57.0':
-    resolution: {integrity: sha512-Wmnx/6ABynVH1iwuoNUqJNyjIUqsqoGML7qsyivBRKb5Wo2YQtPOQlQYfxfZSvWzGpcoSVdInkRjDssUQxQEQg==}
+  '@sentry/feedback@10.58.0':
+    resolution: {integrity: sha512-VmIlR/0O0GXITbvgjPkQqd6yM0JDEk52WXv6Rs1kTdaIDU5h3Y64VDVN4MAbYVRHqSz7F1arjRRk2FkaKC7ZOQ==}
     engines: {node: '>=18'}
 
-  '@sentry/browser@10.57.0':
-    resolution: {integrity: sha512-s36AQy/CKXTfyY9Z+qUhzNomntZXgfs0rbaK7q9ffnFkqcPwzE8qQtVs58y3Suut56u+AhwSztgQtERcuZ5VIA==}
+  '@sentry/replay-canvas@10.58.0':
+    resolution: {integrity: sha512-ufFmaJ968DXGe6u9W/UqNVjCCTtAqT2bNtSu1jHAjIFFpWIuM80lcR33grK6SuGnFxceu5iJFaIW6JRyfbM0Sw==}
     engines: {node: '>=18'}
 
-  '@sentry/core@10.57.0':
-    resolution: {integrity: sha512-kntItTA2kiT0YpL7encXaF6mkdZMB+y48lwj8w1wkfBpfJAC7sifdgrzLQZqmsqVNE3crg9VfufaAGA+78uFMg==}
+  '@sentry/replay@10.58.0':
+    resolution: {integrity: sha512-EVasQNUenpwJksK9DI1TQ78YytpjLAhxn0UTiHqA3sU/s1fHK5XZdZJPr/9uEGedRoInIP0UIWmbOtOEX8HHDg==}
     engines: {node: '>=18'}
 
   '@sinclair/typebox@0.34.49':
@@ -1051,8 +1051,8 @@ packages:
       - yaml
       - mime-types
 
-  aws-cdk@2.1126.0:
-    resolution: {integrity: sha512-uNoocb3vCPiAT3j9+SwL6pn/VVggHWBsgC2XpxyhNvYQYt6cE9BM/149GWwtdcwnLrPjnwW1+CV/5nSSh5dV+w==}
+  aws-cdk@2.1127.0:
+    resolution: {integrity: sha512-/6pUD6+cp3ObwItYEHXF+O+cUCtsKmCoeerCXA/xAfELAAJbdlu36Zx+LJZGbF32aO4xdk3zlH3F7rY657js3g==}
     engines: {node: '>= 18.0.0'}
     hasBin: true
 
@@ -1130,8 +1130,8 @@ packages:
     engines: {node: '>=20.0.0'}
     hasBin: true
 
-  cdk-nag@3.0.0:
-    resolution: {integrity: sha512-nYyG3SyJ+uXjREIFo1X3vqypyqMODqqSPZ/FXd09+ioK2062wWxUvdk7rENOrurcsEXeON1CHUSNr144nUtNDw==}
+  cdk-nag@3.0.1:
+    resolution: {integrity: sha512-Ppa8oDRduUJl9CAzuJzXszg5GmltfQL95BvkTXXdtpOpi801n8ik4gKDjvrJahFikjTBgnJjRsS/2AG3AGVfDg==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
       aws-cdk-lib: ^2.257.0
@@ -2865,33 +2865,33 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 4.0.4
 
-  '@sentry-internal/browser-utils@10.57.0':
+  '@sentry/browser-utils@10.58.0':
     dependencies:
-      '@sentry/core': 10.57.0
+      '@sentry/core': 10.58.0
 
-  '@sentry-internal/feedback@10.57.0':
+  '@sentry/browser@10.58.0':
     dependencies:
-      '@sentry/core': 10.57.0
+      '@sentry/browser-utils': 10.58.0
+      '@sentry/core': 10.58.0
+      '@sentry/feedback': 10.58.0
+      '@sentry/replay': 10.58.0
+      '@sentry/replay-canvas': 10.58.0
 
-  '@sentry-internal/replay-canvas@10.57.0':
+  '@sentry/core@10.58.0': {}
+
+  '@sentry/feedback@10.58.0':
     dependencies:
-      '@sentry-internal/replay': 10.57.0
-      '@sentry/core': 10.57.0
+      '@sentry/core': 10.58.0
 
-  '@sentry-internal/replay@10.57.0':
+  '@sentry/replay-canvas@10.58.0':
     dependencies:
-      '@sentry-internal/browser-utils': 10.57.0
-      '@sentry/core': 10.57.0
+      '@sentry/core': 10.58.0
+      '@sentry/replay': 10.58.0
 
-  '@sentry/browser@10.57.0':
+  '@sentry/replay@10.58.0':
     dependencies:
-      '@sentry-internal/browser-utils': 10.57.0
-      '@sentry-internal/feedback': 10.57.0
-      '@sentry-internal/replay': 10.57.0
-      '@sentry-internal/replay-canvas': 10.57.0
-      '@sentry/core': 10.57.0
-
-  '@sentry/core@10.57.0': {}
+      '@sentry/browser-utils': 10.58.0
+      '@sentry/core': 10.58.0
 
   '@sinclair/typebox@0.34.49': {}
 
@@ -3088,7 +3088,7 @@ snapshots:
       '@aws-cdk/cloud-assembly-schema': 54.2.0
       constructs: 10.6.0
 
-  aws-cdk@2.1126.0: {}
+  aws-cdk@2.1127.0: {}
 
   babel-jest@30.4.1(@babel/core@7.29.0):
     dependencies:
@@ -3226,7 +3226,7 @@ snapshots:
     dependencies:
       commander: 12.1.0
 
-  cdk-nag@3.0.0(aws-cdk-lib@2.259.0(constructs@10.6.0))(constructs@10.6.0):
+  cdk-nag@3.0.1(aws-cdk-lib@2.259.0(constructs@10.6.0))(constructs@10.6.0):
     dependencies:
       aws-cdk-lib: 2.259.0(constructs@10.6.0)
       constructs: 10.6.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,3 @@ allowBuilds:
   "@parcel/watcher": true
   esbuild: true
   unrs-resolver: true
-
-# Supply chain security
-# https://pnpm.io/supply-chain-security
-minimumReleaseAge: 4320 # 3 days, tighter than v11 default of 1440 (1 day)

--- a/spec/concerns/rejects_contact_grants_spec.rb
+++ b/spec/concerns/rejects_contact_grants_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+# Shared coverage for the four permission grant models. `parent` is the grant's owning
+# association (`:collection` or `:item`); the grant is built linking that parent to the user.
+RSpec.shared_examples_for 'rejects contact grants' do |parent|
+  let(:model) { described_class }
+  let(:parent_record) { create(parent) }
+
+  it 'is valid when granted to a real user' do
+    grant = model.new(parent => parent_record, user: create(:user))
+
+    expect(grant).to be_valid
+  end
+
+  it 'is invalid when granted to a contact-only user' do
+    grant = model.new(parent => parent_record, user: create(:user, :contact_only))
+
+    aggregate_failures do
+      expect(grant).not_to be_valid
+      expect(grant.errors[:user]).to include('cannot be a contact-only user; contacts can be attributed but not granted access')
+    end
+  end
+end

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe CollectionsController, type: :controller do
+  let(:manager) { create(:user, admin: true) }
+  let(:editor) { create(:user) }
+  let(:grantee) { create(:user) }
+  let(:evil) { create(:user) }
+
+  let(:collection) do
+    create(
+      :collection,
+      collection_admins: [CollectionAdmin.new(user: editor)],
+      collection_users: [CollectionUser.new(user: grantee)]
+    )
+  end
+
+  def update_collection
+    patch :update, params: {
+      id: collection.identifier,
+      collection: { title: 'Updated title', admin_ids: [evil.id.to_s], user_ids: [''] }
+    }
+  end
+
+  context 'when assigning grants via the collection form' do
+    before { request.env['devise.mapping'] = Devise.mappings[:user] }
+
+    context 'when a non-admin editor submits the form' do
+      before { sign_in(editor, scope: :user) }
+
+      it 'saves metadata changes but leaves grants untouched' do
+        update_collection
+        collection.reload
+        expect(collection.title).to eq('Updated title')
+        expect(collection.admins).to contain_exactly(editor)
+        expect(collection.users).to contain_exactly(grantee)
+      end
+    end
+
+    context 'when an admin submits the form' do
+      before { sign_in(manager, scope: :user) }
+
+      it 'applies the grant changes' do
+        update_collection
+        collection.reload
+        expect(collection.admins).to contain_exactly(evil)
+        expect(collection.users).to be_empty
+      end
+    end
+  end
+end

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -157,6 +157,52 @@ describe ItemsController, type: :controller do
     end
   end
 
+  context 'when assigning grants via the item form' do
+    let(:editor) { create(:user) }
+    let(:grantee) { create(:user) }
+    let(:evil) { create(:user) }
+    let(:granted_item) do
+      create(
+        :item,
+        collection: collection,
+        item_admins: [ItemAdmin.new(user: editor)],
+        item_users: [ItemUser.new(user: grantee)]
+      )
+    end
+    let(:update_params) do
+      {
+        collection_id: collection.identifier,
+        id: granted_item.identifier,
+        item: { title: 'Updated title', admin_ids: [evil.id.to_s], user_ids: [''] }
+      }
+    end
+
+    before { @request.env['devise.mapping'] = Devise.mappings[:user] }
+
+    context 'as a non-admin editor' do
+      before { sign_in(editor, scope: :user) }
+
+      it 'saves metadata changes but leaves grants untouched' do
+        patch :update, params: update_params
+        granted_item.reload
+        expect(granted_item.title).to eq('Updated title')
+        expect(granted_item.admins).to contain_exactly(editor)
+        expect(granted_item.users).to contain_exactly(grantee)
+      end
+    end
+
+    context 'as an admin' do
+      before { sign_in(manager, scope: :user) }
+
+      it 'applies the grant changes' do
+        patch :update, params: update_params
+        granted_item.reload
+        expect(granted_item.admins).to contain_exactly(evil)
+        expect(granted_item.users).to be_empty
+      end
+    end
+  end
+
   context 'when viewing an item with essences' do
     it 'tracks the essence files' do
       get :show, params: params.merge(id: item_with_essences.identifier)

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -11,5 +11,11 @@ FactoryBot.define do
     factory :admin_user do
       admin { true }
     end
+
+    trait :contact_only do
+      contact_only { true }
+      email { nil }
+      confirmed_at { nil }
+    end
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1,0 +1,161 @@
+require 'rails_helper'
+require 'cancan/matchers'
+
+# These specs assert external authorisation behaviour — what a given actor can and
+# cannot do — rather than the internal shape of the membership tables, so they stay
+# valid if those tables are later restructured (Phase 2).
+RSpec.describe Ability do
+  def ability(actor = user)
+    described_class.new(actor)
+  end
+
+  def open_access
+    create(:access_condition, name: 'Open (subject to agreeing to PDSC access conditions)')
+  end
+
+  def closed_access
+    create(:access_condition, name: 'Closed')
+  end
+
+  def private_collection(**attrs)
+    create(:collection, private: true, **attrs)
+  end
+
+  def closed_item(**attrs)
+    create(:item, access_condition: closed_access, private: true, **attrs)
+  end
+
+  describe 'collection collector attribution confers no rights' do
+    let(:user) { create(:user) }
+    let(:collection) { private_collection(collector: user) }
+    let(:item) { closed_item(collection:, collector: user, operator: user) }
+    let(:essence) { create(:sound_essence, item:) }
+
+    it 'cannot read or update the private collection' do
+      aggregate_failures do
+        expect(ability).not_to be_able_to(:read, collection)
+        expect(ability).not_to be_able_to(:update, collection)
+      end
+    end
+
+    it 'cannot manage the collection items' do
+      expect(ability).not_to be_able_to(:manage, item)
+    end
+
+    it 'cannot download the items essences' do
+      expect(ability).not_to be_able_to(:download, essence)
+    end
+
+    it 'cannot manage essence annotations' do
+      expect(ability).not_to be_able_to(:manage, EssenceAnnotation.new(target_essence: essence))
+    end
+  end
+
+  describe 'collection operator attribution confers no rights' do
+    let(:user) { create(:user) }
+    let(:collection) { private_collection(operator: user) }
+    let(:item) { closed_item(collection:, operator: user) }
+
+    it 'cannot read or update the private collection' do
+      aggregate_failures do
+        expect(ability).not_to be_able_to(:read, collection)
+        expect(ability).not_to be_able_to(:update, collection)
+      end
+    end
+
+    it 'cannot manage the collection items' do
+      expect(ability).not_to be_able_to(:manage, item)
+    end
+  end
+
+  describe 'item collector attribution confers no rights' do
+    let(:user) { create(:user) }
+    let(:item) { closed_item(collection: private_collection, collector: user) }
+
+    it 'cannot manage the item' do
+      aggregate_failures do
+        expect(ability).not_to be_able_to(:manage, item)
+        expect(ability).not_to be_able_to(:update, item)
+      end
+    end
+  end
+
+  describe 'collection editor (collection_admins) retains edit' do
+    let(:user) { create(:user) }
+    let(:collection) { private_collection }
+    let(:item) { closed_item(collection:) }
+
+    before { collection.admins << user }
+
+    it 'can read and update the collection and manage its items' do
+      aggregate_failures do
+        expect(ability).to be_able_to(:update, collection)
+        expect(ability).to be_able_to(:manage, item)
+      end
+    end
+  end
+
+  describe 'item editor (item_admins) retains edit and download' do
+    let(:user) { create(:user) }
+    let(:item) { closed_item(collection: private_collection) }
+    let(:essence) { create(:sound_essence, item:) }
+
+    before { item.admins << user }
+
+    it 'can manage the item and download its essences' do
+      aggregate_failures do
+        expect(ability).to be_able_to(:manage, item)
+        expect(ability).to be_able_to(:download, essence)
+      end
+    end
+
+    it 'can manage essence annotations' do
+      expect(ability).to be_able_to(:manage, EssenceAnnotation.new(target_essence: essence))
+    end
+  end
+
+  describe 'item read-only grantee (item_users) retains read and download' do
+    let(:user) { create(:user) }
+    let(:item) { closed_item(collection: private_collection) }
+    let(:essence) { create(:sound_essence, item:) }
+
+    before { item.users << user }
+
+    it 'can read the item and download its closed essences but cannot edit' do
+      aggregate_failures do
+        expect(ability).to be_able_to(:read, item)
+        expect(ability).to be_able_to(:download, essence)
+        expect(ability).not_to be_able_to(:update, item)
+      end
+    end
+  end
+
+  describe 'guests are unchanged' do
+    let(:user) { nil }
+    let(:public_collection) { create(:collection, private: false) }
+    let(:public_item) { create(:item, private: false, access_condition: open_access, collection: public_collection) }
+
+    it 'can read public collections and items but not private ones' do
+      aggregate_failures do
+        expect(ability).to be_able_to(:read, public_collection)
+        expect(ability).to be_able_to(:read, public_item)
+        expect(ability).not_to be_able_to(:read, private_collection)
+      end
+    end
+  end
+
+  describe 'admins are unchanged' do
+    let(:user) { create(:admin_user) }
+    let(:collection) { private_collection }
+    let(:item) { closed_item(collection:) }
+    let(:essence) { create(:sound_essence, item:) }
+
+    it 'can manage everything including closed essences' do
+      aggregate_failures do
+        expect(ability).to be_able_to(:manage, collection)
+        expect(ability).to be_able_to(:manage, item)
+        expect(ability).to be_able_to(:manage, essence)
+      end
+    end
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -25,6 +25,11 @@ RSpec.describe Ability do
     create(:item, access_condition: closed_access, private: true, **attrs)
   end
 
+  # The denormalised Entity record the API authorises against.
+  def entity_for(record)
+    Entity.find_by!(entity_type: record.class.name, entity_id: record.id)
+  end
+
   describe 'collection collector attribution confers no rights' do
     let(:user) { create(:user) }
     let(:collection) { private_collection(collector: user) }
@@ -84,6 +89,7 @@ RSpec.describe Ability do
     let(:user) { create(:user) }
     let(:collection) { private_collection }
     let(:item) { closed_item(collection:) }
+    let(:essence) { create(:sound_essence, item:) }
 
     before { collection.admins << user }
 
@@ -92,6 +98,54 @@ RSpec.describe Ability do
         expect(ability).to be_able_to(:update, collection)
         expect(ability).to be_able_to(:manage, item)
       end
+    end
+
+    it 'can download essences via the primary rule' do
+      expect(ability).to be_able_to(:download, essence)
+    end
+  end
+
+  describe 'collection read-only grantee (collection_users) gets cascading read' do
+    let(:user) { create(:user) }
+    let(:collection) { private_collection }
+    let(:item) { closed_item(collection:) }
+    let(:essence) { create(:sound_essence, item:) }
+
+    before { collection.users << user }
+
+    it 'can read the collection, its private items and the item data view' do
+      aggregate_failures do
+        expect(ability).to be_able_to(:read, collection)
+        expect(ability).to be_able_to(:read, item)
+        expect(ability).to be_able_to(:data, item)
+      end
+    end
+
+    it 'can read, download and display the closed essences' do
+      aggregate_failures do
+        expect(ability).to be_able_to(:read, essence)
+        expect(ability).to be_able_to(:download, essence)
+        expect(ability).to be_able_to(:display, essence)
+      end
+    end
+
+    it 'gets the same read/download via the denormalised Entity records' do
+      aggregate_failures do
+        expect(ability).to be_able_to(:read, entity_for(collection))
+        expect(ability).to be_able_to(:read, entity_for(item))
+        expect(ability).to be_able_to(:download, entity_for(essence))
+      end
+    end
+
+    it 'cannot edit the collection or its items' do
+      aggregate_failures do
+        expect(ability).not_to be_able_to(:update, collection)
+        expect(ability).not_to be_able_to(:update, item)
+      end
+    end
+
+    it 'cannot manage essence annotations' do
+      expect(ability).not_to be_able_to(:manage, EssenceAnnotation.new(target_essence: essence))
     end
   end
 

--- a/spec/models/collection_admin_spec.rb
+++ b/spec/models/collection_admin_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+require Rails.root.join 'spec/concerns/rejects_contact_grants_spec.rb'
+
+describe CollectionAdmin, type: :model do
+  it_behaves_like 'rejects contact grants', :collection
+end

--- a/spec/models/collection_admin_spec.rb
+++ b/spec/models/collection_admin_spec.rb
@@ -9,7 +9,7 @@
 # -------------------- | ------------------ | ---------------------------
 # **`id`**             | `integer`          | `not null, primary key`
 # **`collection_id`**  | `integer`          | `not null`
-# **`user_id`**        | `integer`          | `not null`
+# **`user_id`**        | `bigint`           | `not null`
 #
 # ### Indexes
 #
@@ -20,6 +20,13 @@
 #     * **`user_id`**
 # * `index_collection_admins_on_user_id`:
 #     * **`user_id`**
+#
+# ### Foreign Keys
+#
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`collection_id => collections.id`**
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`user_id => users.id`**
 #
 require 'rails_helper'
 require Rails.root.join 'spec/concerns/rejects_contact_grants_spec.rb'

--- a/spec/models/collection_admin_spec.rb
+++ b/spec/models/collection_admin_spec.rb
@@ -1,3 +1,26 @@
+# ## Schema Information
+#
+# Table name: `collection_admins`
+# Database name: `primary`
+#
+# ### Columns
+#
+# Name                 | Type               | Attributes
+# -------------------- | ------------------ | ---------------------------
+# **`id`**             | `integer`          | `not null, primary key`
+# **`collection_id`**  | `integer`          | `not null`
+# **`user_id`**        | `integer`          | `not null`
+#
+# ### Indexes
+#
+# * `index_collection_admins_on_collection_id`:
+#     * **`collection_id`**
+# * `index_collection_admins_on_collection_id_and_user_id` (_unique_):
+#     * **`collection_id`**
+#     * **`user_id`**
+# * `index_collection_admins_on_user_id`:
+#     * **`user_id`**
+#
 require 'rails_helper'
 require Rails.root.join 'spec/concerns/rejects_contact_grants_spec.rb'
 

--- a/spec/models/collection_user_spec.rb
+++ b/spec/models/collection_user_spec.rb
@@ -1,3 +1,26 @@
+# ## Schema Information
+#
+# Table name: `collection_users`
+# Database name: `primary`
+#
+# ### Columns
+#
+# Name                 | Type               | Attributes
+# -------------------- | ------------------ | ---------------------------
+# **`id`**             | `integer`          | `not null, primary key`
+# **`collection_id`**  | `integer`          | `not null`
+# **`user_id`**        | `integer`          | `not null`
+#
+# ### Indexes
+#
+# * `index_collection_users_on_collection_id`:
+#     * **`collection_id`**
+# * `index_collection_users_on_collection_id_and_user_id` (_unique_):
+#     * **`collection_id`**
+#     * **`user_id`**
+# * `index_collection_users_on_user_id`:
+#     * **`user_id`**
+#
 require 'rails_helper'
 require Rails.root.join 'spec/concerns/rejects_contact_grants_spec.rb'
 

--- a/spec/models/collection_user_spec.rb
+++ b/spec/models/collection_user_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+require Rails.root.join 'spec/concerns/rejects_contact_grants_spec.rb'
+
+describe CollectionUser, type: :model do
+  it_behaves_like 'rejects contact grants', :collection
+end

--- a/spec/models/collection_user_spec.rb
+++ b/spec/models/collection_user_spec.rb
@@ -9,7 +9,7 @@
 # -------------------- | ------------------ | ---------------------------
 # **`id`**             | `integer`          | `not null, primary key`
 # **`collection_id`**  | `integer`          | `not null`
-# **`user_id`**        | `integer`          | `not null`
+# **`user_id`**        | `bigint`           | `not null`
 #
 # ### Indexes
 #
@@ -20,6 +20,13 @@
 #     * **`user_id`**
 # * `index_collection_users_on_user_id`:
 #     * **`user_id`**
+#
+# ### Foreign Keys
+#
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`collection_id => collections.id`**
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`user_id => users.id`**
 #
 require 'rails_helper'
 require Rails.root.join 'spec/concerns/rejects_contact_grants_spec.rb'

--- a/spec/models/item_admin_spec.rb
+++ b/spec/models/item_admin_spec.rb
@@ -9,13 +9,22 @@
 # -------------- | ------------------ | ---------------------------
 # **`id`**       | `integer`          | `not null, primary key`
 # **`item_id`**  | `integer`          | `not null`
-# **`user_id`**  | `integer`          | `not null`
+# **`user_id`**  | `bigint`           | `not null`
 #
 # ### Indexes
 #
 # * `index_item_admins_on_item_id_and_user_id` (_unique_):
 #     * **`item_id`**
 #     * **`user_id`**
+# * `index_item_admins_on_user_id`:
+#     * **`user_id`**
+#
+# ### Foreign Keys
+#
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`item_id => items.id`**
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`user_id => users.id`**
 #
 require 'rails_helper'
 require Rails.root.join 'spec/concerns/rejects_contact_grants_spec.rb'

--- a/spec/models/item_admin_spec.rb
+++ b/spec/models/item_admin_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+require Rails.root.join 'spec/concerns/rejects_contact_grants_spec.rb'
+
+describe ItemAdmin, type: :model do
+  it_behaves_like 'rejects contact grants', :item
+end

--- a/spec/models/item_admin_spec.rb
+++ b/spec/models/item_admin_spec.rb
@@ -1,3 +1,22 @@
+# ## Schema Information
+#
+# Table name: `item_admins`
+# Database name: `primary`
+#
+# ### Columns
+#
+# Name           | Type               | Attributes
+# -------------- | ------------------ | ---------------------------
+# **`id`**       | `integer`          | `not null, primary key`
+# **`item_id`**  | `integer`          | `not null`
+# **`user_id`**  | `integer`          | `not null`
+#
+# ### Indexes
+#
+# * `index_item_admins_on_item_id_and_user_id` (_unique_):
+#     * **`item_id`**
+#     * **`user_id`**
+#
 require 'rails_helper'
 require Rails.root.join 'spec/concerns/rejects_contact_grants_spec.rb'
 

--- a/spec/models/item_user_spec.rb
+++ b/spec/models/item_user_spec.rb
@@ -1,3 +1,22 @@
+# ## Schema Information
+#
+# Table name: `item_users`
+# Database name: `primary`
+#
+# ### Columns
+#
+# Name           | Type               | Attributes
+# -------------- | ------------------ | ---------------------------
+# **`id`**       | `integer`          | `not null, primary key`
+# **`item_id`**  | `integer`          | `not null`
+# **`user_id`**  | `integer`          | `not null`
+#
+# ### Indexes
+#
+# * `index_item_users_on_item_id_and_user_id` (_unique_):
+#     * **`item_id`**
+#     * **`user_id`**
+#
 require 'rails_helper'
 require Rails.root.join 'spec/concerns/rejects_contact_grants_spec.rb'
 

--- a/spec/models/item_user_spec.rb
+++ b/spec/models/item_user_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+require Rails.root.join 'spec/concerns/rejects_contact_grants_spec.rb'
+
+describe ItemUser, type: :model do
+  it_behaves_like 'rejects contact grants', :item
+end

--- a/spec/models/item_user_spec.rb
+++ b/spec/models/item_user_spec.rb
@@ -9,13 +9,22 @@
 # -------------- | ------------------ | ---------------------------
 # **`id`**       | `integer`          | `not null, primary key`
 # **`item_id`**  | `integer`          | `not null`
-# **`user_id`**  | `integer`          | `not null`
+# **`user_id`**  | `bigint`           | `not null`
 #
 # ### Indexes
 #
 # * `index_item_users_on_item_id_and_user_id` (_unique_):
 #     * **`item_id`**
 #     * **`user_id`**
+# * `index_item_users_on_user_id`:
+#     * **`user_id`**
+#
+# ### Foreign Keys
+#
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`item_id => items.id`**
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`user_id => users.id`**
 #
 require 'rails_helper'
 require Rails.root.join 'spec/concerns/rejects_contact_grants_spec.rb'

--- a/spec/requests/users_picker_spec.rb
+++ b/spec/requests/users_picker_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+# The /users endpoint backs every user-picker. Grant pickers pass exclude_contacts=true so contacts
+# (who can never hold a grant) are filtered out; attribution pickers (collector/operator) omit it so
+# contacts remain selectable.
+describe 'Users picker', type: :request do
+  let!(:real_user) { create(:user, first_name: 'Real', last_name: 'Researcher') }
+  let!(:contact) { create(:user, :contact_only, first_name: 'Contact', last_name: 'Person') }
+
+  before { sign_in create(:user) }
+
+  def picker_ids(params)
+    get users_path, params: params
+    JSON.parse(response.body)['results'].map { |r| r['value'] }
+  end
+
+  it 'excludes contact-only users from grant pickers' do
+    ids = picker_ids(q: 'Person', exclude_contacts: true)
+
+    expect(ids).not_to include(contact.id)
+  end
+
+  it 'includes real users in grant pickers' do
+    ids = picker_ids(q: 'Researcher', exclude_contacts: true)
+
+    expect(ids).to include(real_user.id)
+  end
+
+  it 'includes contact-only users in attribution pickers' do
+    ids = picker_ids(q: 'Person')
+
+    expect(ids).to include(contact.id)
+  end
+end

--- a/spec/services/collection_destruction_service_spec.rb
+++ b/spec/services/collection_destruction_service_spec.rb
@@ -21,4 +21,27 @@ describe CollectionDestructionService do
       expect(Entity.where(entity_type: 'Essence', entity_id: essence.id)).not_to exist
     end
   end
+
+  # Regression: items are removed with delete_all, which bypasses the `dependent: :destroy`
+  # cleanup on item_admins/item_users. Combined with the collection's own collection_users
+  # read-only grants, this previously left orphaned membership/grant rows behind.
+  context 'when the collection and its items have membership grants', :no_catalog_upload do
+    let(:collection) { create(:collection) }
+    let(:item) { create(:item, collection:) }
+    let(:grantee) { create(:user) }
+
+    before do
+      allow(Nabu::Catalog.instance).to receive_messages(delete_item: 0, delete_collection: 0)
+      collection.collection_users << CollectionUser.new(user: grantee)
+      item.item_admins << ItemAdmin.new(user: grantee)
+      item.item_users << ItemUser.new(user: grantee)
+    end
+
+    it 'removes the items edit and read-only membership rows and the collection read-only grants' do
+      expect(described_class.destroy(collection)[:success]).to be(true)
+      expect(ItemAdmin.where(item_id: item.id)).not_to exist
+      expect(ItemUser.where(item_id: item.id)).not_to exist
+      expect(CollectionUser.where(collection_id: collection.id)).not_to exist
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Implements **Permissions Phase 1** — separating *attribution* (collector/operator) from *access* (grants/memberships). Parent: #1127.

Attribution no longer confers rights; access is held explicitly via the grant/membership tables. Includes a new read-only collection membership, admin-only grant assignment, a contact-grant invariant, the one-off backfill/audit tooling needed for the production cutover, deletion cleanup + DB-level cascade hardening, and the production deploy runbook.

## What's included

| Issue | Change |
| ----- | ------ |
| #1128 | Ability: remove attribution-confers-rights |
| #1129 | Collection read-only grant via new `collection_users` membership |
| #1130 | Admin-only grant assignment on collection and item forms |
| #1131 | Contact-grant invariant (reject contact-only users from grants) |
| #1132 | `Permissions::CollectorBackfill` service + `permissions:collector_backfill` rake task |
| #1133 | `Permissions::ContactGrantAuditor` + `permissions:contact_grants_report` / `_cleanup` (with `PRUNE_ORPHANS`) |
| #1134 | Collection deletion cleans up membership rows and grants |
| #1136 | DB-level `on_delete: :cascade` FKs on membership tables |
| #1135 | Production deploy runbook (`docs/runbooks/permissions-phase1-deploy.md`) |

## Deploy

This is a coordinated production cutover. Follow `docs/runbooks/permissions-phase1-deploy.md`:
banner → deploy → **`db:migrate` (explicit — not auto-run on boot)** → `collector_backfill` → contamination report → **human review** → cleanup → orphan prune (separate step) → single bulk reindex → drop banner → spot-check.

A brief lockout window for real collectors (between deploy and backfill) is expected and acceptable; the announcement banner covers it.

## Notes

- Migrations are **not** applied automatically on container boot — `bin/docker-entrypoint`'s `db:prepare` guard doesn't match the production `CMD`. They must be run explicitly via `bin/aws/ecs_rake app db:migrate`. The runbook documents this.
- Backfill and audit tooling suppress Searchkick callbacks; search is rebuilt once via an explicit `search:reindex` step.

Closes #1127, #1128, #1129, #1130, #1131, #1132, #1133, #1134, #1135, #1136