### PR TITLE
Permissions Phase 2: unify membership tables into a polymorphic Permission grant

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -134,6 +134,8 @@ RSpec/ExampleLength:
     - 'spec/models/permission_spec.rb'
     - 'spec/models/user_duplicate_name_spec.rb'
     - 'spec/requests/api/v1/graphql_oauth_spec.rb'
+    - 'spec/services/permissions/backfill_spec.rb'
+    - 'spec/services/permissions/item_edit_dedup_auditor_spec.rb'
     - 'spec/services/user_merger_service_spec.rb'
 
 # Offense count: 8

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -131,6 +131,7 @@ RSpec/ExampleLength:
     - 'spec/controllers/items_controller_spec.rb'
     - 'spec/features/search_collections_spec.rb'
     - 'spec/features/search_items_spec.rb'
+    - 'spec/models/permission_spec.rb'
     - 'spec/models/user_duplicate_name_spec.rb'
     - 'spec/requests/api/v1/graphql_oauth_spec.rb'
     - 'spec/services/user_merger_service_spec.rb'

--- a/app/controllers/api/v1/oni_controller.rb
+++ b/app/controllers/api/v1/oni_controller.rb
@@ -81,7 +81,7 @@ module Api
         if items.any?
           ActiveRecord::Associations::Preloader.new(
             records: items,
-            associations: [:item_admins, :item_users, :access_condition, { collection: :collection_admins }]
+            associations: [:item_permissions, :access_condition, { collection: :collection_permissions }]
           ).call
         end
 
@@ -91,7 +91,7 @@ module Api
         if collections.any?
           ActiveRecord::Associations::Preloader.new(
             records: collections,
-            associations: [:collection_admins, { items: [:essences, :item_admins, :item_users, :access_condition] }]
+            associations: [:collection_permissions, { items: [:essences, :item_permissions, :access_condition] }]
           ).call
         end
       end

--- a/app/controllers/api/v1/oni_controller.rb
+++ b/app/controllers/api/v1/oni_controller.rb
@@ -238,19 +238,10 @@ module Api
         perms = []
         unless current_user&.admin?
           perms << { private: false }
-          if current_user
-            Collection.search_user_fields.each do |field|
-              perms << { field => current_user.id }
-            end
-
-            Item.search_user_fields.each do |field|
-              perms << { field => current_user.id }
-            end
-
-            Essence.search_user_fields.each do |field|
-              perms << { field => current_user.id }
-            end
-          end
+          # Collection, Item and Essence documents all carry a single deduped access_user_ids union
+          # (the full read-visibility set), so one clause covers every entity type in this cross-index
+          # search. Mirrors HasSearch#visibility_clauses.
+          perms << { access_user_ids: current_user.id } if current_user
         end
 
         where = {

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -60,7 +60,7 @@ class CollectionsController < ApplicationController
 
     # Preload the associations CanCan traverses in can?(:read/:update, item) to avoid N+1 queries
     @items = @collection.items
-      .includes(:access_condition, :essences, :admins, :users, :item_admins, :item_users, collection: :collection_admins)
+      .includes(:access_condition, :essences, :admins, :users, :item_permissions, collection: :collection_permissions)
       .page(params[:items_page]).per(params[:items_per_page])
 
     sort_column = Item.column_names.include?(params[:sort]) ? params[:sort] : 'identifier'

--- a/app/controllers/concerns/has_search.rb
+++ b/app/controllers/concerns/has_search.rb
@@ -68,9 +68,9 @@ module HasSearch
   # Single source of truth for "which documents may current_user see" in search.
   #
   # Returns :all for admins (no restriction), otherwise a list of alternative match clauses
-  # with OR semantics: a document is visible if it is public OR current_user is listed in any
-  # of the model's permission fields. This mirrors the :read grants in app/models/ability.rb -
-  # model.search_user_fields is the denormalised mirror of those grants.
+  # with OR semantics: a document is visible if it is public OR current_user is in the document's
+  # access_user_ids union (the deduped set of everyone-who-can-read). This mirrors the :read grants
+  # in app/models/ability.rb - model.search_user_fields is the denormalised mirror of those grants.
   #
   # Both search families consume this one method so they cannot drift: the basic search
   # (Searchkick `where`, via basic_search_where) and the advanced search (raw OpenSearch

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -14,23 +14,31 @@
 #   Edit      | yes          | yes                   | yes  | no
 #   Admin     | yes          | yes                   | yes  | yes
 #
-# Each non-admin tier is backed by a membership join table (user_id + the record):
+# Each non-admin tier is backed by a row in the single polymorphic `permissions` table
+# (user_id + the polymorphic `grantable` record + a `level` of read or edit):
 #
-#   Tier      | Collection level  | Item level
-#   --------- | ----------------- | ----------
-#   Read-only | collection_users  | item_users
-#   Edit      | collection_admins | item_admins
+#   Tier      | Grantable  | level
+#   --------- | ---------- | -----
+#   Read-only | Collection | read
+#   Edit      | Collection | edit
+#   Read-only | Item       | read
+#   Edit      | Item       | edit
 #
-#   A collection_users grant CASCADES to every item in the collection and its essences —
-#   see the `collection: { collection_users: ... }` rules below. Admin is the `admin`
-#   boolean on User and short-circuits everything via `can :manage, :all`.
+#   A collection-level read grant CASCADES to every item in the collection and its essences —
+#   see the `collection: { collection_permissions: { level: 'read' } }` rules below. Admin is
+#   the `admin` boolean on User and short-circuits everything via `can :manage, :all`.
+#   Grants are read through polymorphic associations that inject the correct `grantable_type`;
+#   the explicit `level:` keeps read and edit genuinely distinguished. Collection and Item name
+#   these associations differently (`collection_permissions` vs `item_permissions`) so that
+#   accessible_by, when one rule traverses both levels, generates distinct join aliases rather
+#   than colliding on a single `permissions` name.
 #
 # CROSS-CUTTING RULES — enforced elsewhere, noted here so the whole policy reads in one place:
 #   * Preservation masters (.mxf/.mkv, Essence#is_archived?) are admin-only. NOT enforced
 #     here — see EssencesController#download/#display and Api::V1::OniController, which
 #     reject non-admins regardless of any grant below.
 #   * Contacts (contact_only users) can never hold a grant. Enforced by the
-#     RejectsContactGrants concern on the four membership models, not here.
+#     RejectsContactGrants concern on the Permission model, not here.
 #   * Grant assignment is admin-only — the grant fields are admin-gated in the collection
 #     and item controllers/forms, so a non-admin's save never adds or removes a grant.
 #
@@ -105,16 +113,16 @@ class Ability
     can :read, Entity, entity_type: 'Collection', collection: { private: false }
 
     # Members of any item in a collection can read the collection
-    can :read, Collection, items: { item_users: { user_id: user.id } }
-    can :read, Entity, entity_type: 'Collection', collection: { items: { item_users: { user_id: user.id } } }
-    can :read, Collection, items: { item_admins: { user_id: user.id } }
-    can :read, Entity, entity_type: 'Collection', collection: { items: { item_admins: { user_id: user.id } } }
-    can %i[read update], Collection, collection_admins: { user_id: user.id }
-    can :read, Entity, entity_type: 'Collection', collection: { collection_admins: { user_id: user.id } }
+    can :read, Collection, items: { item_permissions: { user_id: user.id, level: 'read' } }
+    can :read, Entity, entity_type: 'Collection', collection: { items: { item_permissions: { user_id: user.id, level: 'read' } } }
+    can :read, Collection, items: { item_permissions: { user_id: user.id, level: 'edit' } }
+    can :read, Entity, entity_type: 'Collection', collection: { items: { item_permissions: { user_id: user.id, level: 'edit' } } }
+    can %i[read update], Collection, collection_permissions: { user_id: user.id, level: 'edit' }
+    can :read, Entity, entity_type: 'Collection', collection: { collection_permissions: { user_id: user.id, level: 'edit' } }
 
-    # collection_users are read-only grantees of the whole collection
-    can :read, Collection, collection_users: { user_id: user.id }
-    can :read, Entity, entity_type: 'Collection', collection: { collection_users: { user_id: user.id } }
+    # read-level permissions are read-only grantees of the whole collection
+    can :read, Collection, collection_permissions: { user_id: user.id, level: 'read' }
+    can :read, Entity, entity_type: 'Collection', collection: { collection_permissions: { user_id: user.id, level: 'read' } }
 
     # Only admins can create a collection
     cannot :create, Collection
@@ -137,18 +145,22 @@ class Ability
     can %i[read data], Item, { private: false, collection: { private: false } }
     can :read, Entity, entity_type: 'Item', item: { private: false, collection: { private: false } }
 
-    can %i[read data], Item, item_users: { user_id: user.id }
-    can :read, Entity, entity_type: 'Item', item: { item_users: { user_id: user.id } }
-    can %i[read data], Item, item_admins: { user_id: user.id }
-    can :read, Entity, entity_type: 'Item', item: { item_admins: { user_id: user.id } }
+    can %i[read data], Item, item_permissions: { user_id: user.id, level: 'read' }
+    can :read, Entity, entity_type: 'Item', item: { item_permissions: { user_id: user.id, level: 'read' } }
+    can %i[read data], Item, item_permissions: { user_id: user.id, level: 'edit' }
+    can :read, Entity, entity_type: 'Item', item: { item_permissions: { user_id: user.id, level: 'edit' } }
 
-    can %i[read data], Item, collection: { collection_users: { user_id: user.id } }
-    can :read, Entity, entity_type: 'Item', item: { collection: { collection_users: { user_id: user.id } } }
+    # The collection cascade: the Item rule reaches the collection's grant directly via
+    # collection_grant_permissions (top-level, so accessible_by aligns its aliases — see Item),
+    # while the Entity rule nests through item/collection because Entity is polymorphic and its
+    # accessible_by already tolerates the nested form. Both express the same access.
+    can %i[read data], Item, collection_grant_permissions: { user_id: user.id, level: 'read' }
+    can :read, Entity, entity_type: 'Item', item: { collection: { collection_permissions: { user_id: user.id, level: 'read' } } }
 
-    can :manage, Item, collection: { collection_admins: { user_id: user.id } }
-    can :read, Entity, entity_type: 'Item', item: { collection: { collection_admins: { user_id: user.id } } }
-    can :manage, Item, item_admins: { user_id: user.id }
-    can :read, Entity, entity_type: 'Item', item: { item_admins: { user_id: user.id } }
+    can :manage, Item, collection_grant_permissions: { user_id: user.id, level: 'edit' }
+    can :read, Entity, entity_type: 'Item', item: { collection: { collection_permissions: { user_id: user.id, level: 'edit' } } }
+    can :manage, Item, item_permissions: { user_id: user.id, level: 'edit' }
+    can :read, Entity, entity_type: 'Item', item: { item_permissions: { user_id: user.id, level: 'edit' } }
 
     can :advanced_search, Item
     can :new_report, Item
@@ -170,14 +182,14 @@ class Ability
     can %i[read download display entities], Essence,
       item: { access_condition: { name: 'Open (subject to agreeing to PDSC access conditions)' } }
     can %i[read download], Entity, entity_type: 'Essence', essence: { item: { access_condition: { name: 'Open (subject to agreeing to PDSC access conditions)' } } }
-    can %i[read download display], Essence, item: { collection: { collection_admins: { user_id: user.id } } }
-    can %i[read download], Entity, entity_type: 'Essence', essence: { item: { collection: { collection_admins: { user_id: user.id } } } }
-    can %i[read download display], Essence, item: { collection: { collection_users: { user_id: user.id } } }
-    can %i[read download], Entity, entity_type: 'Essence', essence: { item: { collection: { collection_users: { user_id: user.id } } } }
-    can %i[read download display], Essence, item: { item_admins: { user_id: user.id } }
-    can %i[read download], Entity, entity_type: 'Essence', essence: { item: { item_admins: { user_id: user.id } } }
-    can %i[read download display], Essence, item: { item_users: { user_id: user.id } }
-    can %i[read download], Entity, entity_type: 'Essence', essence: { item: { item_users: { user_id: user.id } } }
+    can %i[read download display], Essence, item: { collection: { collection_permissions: { user_id: user.id, level: 'edit' } } }
+    can %i[read download], Entity, entity_type: 'Essence', essence: { item: { collection: { collection_permissions: { user_id: user.id, level: 'edit' } } } }
+    can %i[read download display], Essence, item: { collection: { collection_permissions: { user_id: user.id, level: 'read' } } }
+    can %i[read download], Entity, entity_type: 'Essence', essence: { item: { collection: { collection_permissions: { user_id: user.id, level: 'read' } } } }
+    can %i[read download display], Essence, item: { item_permissions: { user_id: user.id, level: 'edit' } }
+    can %i[read download], Entity, entity_type: 'Essence', essence: { item: { item_permissions: { user_id: user.id, level: 'edit' } } }
+    can %i[read download display], Essence, item: { item_permissions: { user_id: user.id, level: 'read' } }
+    can %i[read download], Entity, entity_type: 'Essence', essence: { item: { item_permissions: { user_id: user.id, level: 'read' } } }
 
     can :create, Comment, commentable: { private: false }
 
@@ -185,8 +197,8 @@ class Ability
     # EssenceAnnotation
     #############
 
-    can :manage, EssenceAnnotation, target_essence: { item: { item_admins: { user_id: user.id } } }
-    can :manage, EssenceAnnotation, target_essence: { item: { collection: { collection_admins: { user_id: user.id } } } }
+    can :manage, EssenceAnnotation, target_essence: { item: { item_permissions: { user_id: user.id, level: 'edit' } } }
+    can :manage, EssenceAnnotation, target_essence: { item: { collection: { collection_permissions: { user_id: user.id, level: 'edit' } } } }
   end
 end
 # rubocop:enable Metrics/AbcSize,Metrics/MethodLength

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -43,9 +43,9 @@
 #     and item controllers/forms, so a non-admin's save never adds or removes a grant.
 #
 # SEARCH VISIBILITY: the :read rules here are the canonical policy; the search indexes
-#   mirror them via denormalised id fields (see the Item note below and
-#   spec/features/search_authorisation_consistency_spec.rb). Change a read path here and
-#   you must update the matching index field and that spec.
+#   mirror them via a single denormalised access_user_ids union per document (see the Item note
+#   below and spec/features/search_authorisation_consistency_spec.rb). Change a read path here and
+#   you must update the access_user_ids union in search_data and that spec.
 # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
 class Ability
   include CanCan::Ability
@@ -138,10 +138,11 @@ class Ability
     #############
 
     # NOTE: these Item :read grants are the canonical visibility policy. The search indexes
-    # mirror them via denormalised id fields (Item.search_user_fields -> admin_ids, user_ids,
-    # collection_user_ids, collection_admin_ids) consumed by HasSearch#visibility_clauses.
-    # If you add or remove a read path here, update the matching index field and
-    # spec/features/search_authorisation_consistency_spec.rb, which pins the two together.
+    # mirror them via a single denormalised access_user_ids union (Item.search_user_fields ->
+    # access_user_ids = item editors + read-grantees + collection editors + read-grantees)
+    # consumed by HasSearch#visibility_clauses. If you add or remove a read path here, update the
+    # access_user_ids union in search_data and spec/features/search_authorisation_consistency_spec.rb,
+    # which pins the two together.
     can %i[read data], Item, { private: false, collection: { private: false } }
     can :read, Entity, entity_type: 'Item', item: { private: false, collection: { private: false } }
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -227,8 +227,12 @@ class Collection < ApplicationRecord
     [:collector, :countries, :languages, :university, :admins, :users, items: [:admins, :users]]
   end
 
+  # Search only ever answers "can this person read this?", so visibility collapses to a single
+  # deduped union of everyone-who-can-read (see access_user_ids in search_data). This mirrors the
+  # Collection :read grants in app/models/ability.rb - keep the two in step. The consistency is
+  # pinned by spec/features/search_authorisation_consistency_spec.rb.
   def self.search_user_fields
-    %i[admin_ids user_ids item_admin_ids item_user_ids]
+    %i[access_user_ids]
   end
 
   def self.search_agg_fields
@@ -257,6 +261,9 @@ class Collection < ApplicationRecord
                         }
 
   def search_data
+    # Computed once and reused for both the admin_ids facet field and the access_user_ids union below.
+    admin_ids = admins.map(&:id)
+
     data = {
       # Extra things for basic full text search
       entity_type: 'Collection',
@@ -304,10 +311,11 @@ class Collection < ApplicationRecord
       university_id:,
       country_ids: countries.map(&:id).uniq,
       language_ids: languages.map(&:id).uniq,
-      admin_ids: admins.map(&:id).uniq,
-      user_ids: users.map(&:id).uniq,
-      item_admin_ids: items.flat_map(&:admin_ids).uniq,
-      item_user_ids: items.flat_map(&:user_ids).uniq,
+      # admin_ids survives as the advanced-search "Edit access" facet (see search_filter_fields).
+      admin_ids: admin_ids.uniq,
+      # Read-visibility union: collection editors + read-grantees + every item's editors + read-grantees
+      # (preserving "member of any item => can read the collection"). Consumed by HasSearch#visibility_clauses.
+      access_user_ids: (admin_ids + users.map(&:id) + items.flat_map(&:admin_ids) + items.flat_map(&:user_ids)).uniq,
       access_condition_id:,
       field_of_research_id:,
       funding_body_id: grants.map(&:funding_body_id).uniq,

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -88,11 +88,22 @@ class Collection < ApplicationRecord
   has_many :countries, through: :collection_countries, validate: true
   has_many :item_countries, -> { distinct }, through: :items, source: :countries
 
-  has_many :collection_admins, dependent: :destroy, autosave: true
-  has_many :admins, through: :collection_admins, validate: true, source: :user, autosave: true
+  # Access grants live in the single polymorphic `permissions` table (see Permission). Exposed to
+  # Ability/CanCanCan as a plain (non-polymorphic) association keyed on grantable_id with a
+  # grantable_type scope, so accessible_by builds correctly-aliased SQL joins. Named differently
+  # from Item#item_permissions so a query joining both (item reachable via its collection's grant)
+  # gets distinct join aliases — the collision the four distinct old tables used to avoid.
+  has_many :collection_permissions, -> { where(grantable_type: 'Collection') }, foreign_key: :grantable_id, class_name: 'Permission', dependent: :destroy
 
-  has_many :collection_users, dependent: :destroy, autosave: true
-  has_many :users, through: :collection_users, validate: true, source: :user, autosave: true
+  # The `admins`/`users` names are preserved as level-scoped (polymorphic) associations so the
+  # `admin_ids=`/`user_ids=` form setters and the show views stay unchanged: admins are edit-level
+  # grantees, users are read-level grantees.
+
+  has_many :edit_permissions, -> { where(level: :edit) }, as: :grantable, class_name: 'Permission', autosave: true
+  has_many :admins, through: :edit_permissions, validate: true, source: :user, autosave: true
+
+  has_many :read_permissions, -> { where(level: :read) }, as: :grantable, class_name: 'Permission', autosave: true
+  has_many :users, through: :read_permissions, validate: true, source: :user, autosave: true
 
   # require presence of these three fields
   validates :identifier,

--- a/app/models/essence.rb
+++ b/app/models/essence.rb
@@ -68,8 +68,8 @@ class Essence < ApplicationRecord
     includes(item: [
       :collection, :collector, :operator,
       :content_languages, :countries,
-      :item_admins, :item_users,
-      { collection: %i[collection_admins collection_users] }
+      :admins, :users,
+      { collection: %i[admins users] }
     ])
   }
 
@@ -215,12 +215,12 @@ class Essence < ApplicationRecord
       collection_title: item.collection.title,
 
       private: item.private? || item.collection.private?,
-      admin_ids: item.item_admins.map(&:user_id).uniq,
-      user_ids: item.item_users.map(&:user_id).uniq,
+      admin_ids: item.admins.map(&:id).uniq,
+      user_ids: item.users.map(&:id).uniq,
       collector_id: item.collector_id,
       operator_id: item.operator_id,
-      collection_admin_ids: item.collection.collection_admins.map(&:user_id).uniq,
-      collection_user_ids: item.collection.collection_users.map(&:user_id).uniq,
+      collection_admin_ids: item.collection.admins.map(&:id).uniq,
+      collection_user_ids: item.collection.users.map(&:id).uniq,
 
       originated_on: item.originated_on,
       created_at: created_at&.to_date,
@@ -249,8 +249,8 @@ class Essence < ApplicationRecord
   end
 
   def self.search_includes
-    [{ item: [:collection, :collector, :content_languages, :countries, :item_admins, :item_users,
-              { collection: %i[collection_admins collection_users] }] }, :entity]
+    [{ item: [:collection, :collector, :content_languages, :countries, :admins, :users,
+              { collection: %i[admins users] }] }, :entity]
   end
 
   def self.ransackable_attributes(_ = nil)

--- a/app/models/essence.rb
+++ b/app/models/essence.rb
@@ -215,12 +215,13 @@ class Essence < ApplicationRecord
       collection_title: item.collection.title,
 
       private: item.private? || item.collection.private?,
-      admin_ids: item.admins.map(&:id).uniq,
-      user_ids: item.users.map(&:id).uniq,
       collector_id: item.collector_id,
       operator_id: item.operator_id,
-      collection_admin_ids: item.collection.admins.map(&:id).uniq,
-      collection_user_ids: item.collection.users.map(&:id).uniq,
+      # Read-visibility union: item editors + read-grantees + collection editors + read-grantees.
+      # Consumed by HasSearch#visibility_clauses (an essence inherits its item's/collection's visibility).
+      # Essences have no advanced-search facets, so unlike Collection/Item they carry no separate
+      # admin_ids/user_ids fields - the union is the only permission data indexed here.
+      access_user_ids: (item.admins.map(&:id) + item.users.map(&:id) + item.collection.admins.map(&:id) + item.collection.users.map(&:id)).uniq,
 
       originated_on: item.originated_on,
       created_at: created_at&.to_date,
@@ -229,7 +230,7 @@ class Essence < ApplicationRecord
   end
 
   def self.search_user_fields
-    %i[admin_ids user_ids collection_admin_ids collection_user_ids]
+    %i[access_user_ids]
   end
 
   def self.search_agg_fields
@@ -241,7 +242,7 @@ class Essence < ApplicationRecord
   end
 
   def self.search_filter_fields
-    %i[private collector_id operator_id admin_ids user_ids collection_admin_ids mimetype]
+    %i[private collector_id operator_id mimetype]
   end
 
   def self.search_highlight_fields

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -235,7 +235,6 @@ class Item < ApplicationRecord
     self.access_condition_id ||= collection.access_condition_id
     self.access_narrative ||= collection.access_narrative
     self.private ||= collection.private
-    self.admin_ids ||= collection.admin_ids
   end
 
   def inherit_details_from_collection(override = false)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -96,11 +96,25 @@ class Item < ApplicationRecord
   has_many :item_content_languages, dependent: :destroy
   has_many :content_languages, through: :item_content_languages, source: :language, validate: true
 
-  has_many :item_admins, dependent: :destroy
-  has_many :admins, through: :item_admins, validate: true, source: :user
+  # Access grants live in the single polymorphic `permissions` table (see Permission). These are
+  # exposed to Ability/CanCanCan as plain (non-polymorphic) associations keyed on grantable_id
+  # with a grantable_type scope: unlike a polymorphic `as: :grantable` association, this lets
+  # accessible_by build correctly-aliased SQL joins. `item_permissions` is the item's own grants.
+  has_many :item_permissions, -> { where(grantable_type: 'Item') }, foreign_key: :grantable_id, class_name: 'Permission', dependent: :destroy
+  # The item's collection's grants, reached directly (permissions.grantable_id = items.collection_id)
+  # rather than nested under `collection:`. Keeping every permission join at the top level of the
+  # Item ruleset is what lets accessible_by align its JOIN and WHERE aliases for the one table.
+  has_many :collection_grant_permissions, -> { where(grantable_type: 'Collection') },
+           primary_key: :collection_id, foreign_key: :grantable_id, class_name: 'Permission'
 
-  has_many :item_users, dependent: :destroy
-  has_many :users, through: :item_users, validate: true, source: :user
+  # The `admins`/`users` names are preserved as level-scoped (polymorphic) associations so the
+  # `admin_ids=`/`user_ids=` form setters and the show views stay unchanged: admins are edit-level
+  # grantees, users are read-level grantees.
+  has_many :edit_permissions, -> { where(level: :edit) }, as: :grantable, class_name: 'Permission'
+  has_many :admins, through: :edit_permissions, validate: true, source: :user
+
+  has_many :read_permissions, -> { where(level: :read) }, as: :grantable, class_name: 'Permission'
+  has_many :users, through: :read_permissions, validate: true, source: :user
 
   has_many :item_agents, dependent: :destroy
   has_many :agents, through: :item_agents, validate: true, source: :user
@@ -267,7 +281,7 @@ class Item < ApplicationRecord
   def self.search_includes
     includes = %i[
       collection collector countries operator essences university content_languages
-      data_categories data_types discourse_type access_condition subject_languages item_admins
+      data_categories data_types discourse_type access_condition subject_languages admins users
     ]
     includes << { item_agents: %i[user agent_role] }
 
@@ -316,11 +330,11 @@ class Item < ApplicationRecord
 
   scope :search_import,
         lambda {
-          includes(:users, :content_languages, :subject_languages, :countries, :university, :data_types, :data_categories, :discourse_type,
+          includes(:content_languages, :subject_languages, :countries, :university, :data_types, :data_categories, :discourse_type,
                    :essences, :collector, :operator,
-                   :item_admins, :item_agents, :item_users,
+                   :admins, :users, :item_agents,
                    :access_condition,
-                   collection: :collection_users
+                   collection: %i[admins users]
                   )
         }
 
@@ -384,11 +398,11 @@ class Item < ApplicationRecord
       university_id:,
       access_condition_id:,
       discourse_type_id:,
-      admin_ids: item_admins.map(&:user_id).uniq,
+      admin_ids: admins.map(&:id).uniq,
       agent_ids: item_agents.map(&:user_id).uniq,
-      user_ids: item_users.map(&:user_id).uniq,
-      collection_user_ids: collection.collection_users.map(&:user_id).uniq,
-      collection_admin_ids: collection.collection_admins.map(&:user_id).uniq,
+      user_ids: users.map(&:id).uniq,
+      collection_user_ids: collection.users.map(&:id).uniq,
+      collection_admin_ids: collection.admins.map(&:id).uniq,
       originated_on:,
       metadata_exportable:,
       born_digital:,
@@ -720,9 +734,9 @@ class Item < ApplicationRecord
   def self.ransackable_associations(_auth_object = nil)
     %w[
       access_condition admins agents collection collector comments content_languages countries
-      data_categories data_types discourse_type essences item_admins item_agents
+      data_categories data_types discourse_type essences item_agents permissions
       item_content_languages item_countries item_data_categories item_data_types
-      item_subject_languages item_users operator subject_languages university users versions
+      item_subject_languages operator subject_languages university users versions
     ]
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -288,12 +288,12 @@ class Item < ApplicationRecord
     includes
   end
 
-  # Fields holding the user ids allowed to see a private item. Consumed by
-  # HasSearch#visibility_clauses to filter search results. This list is the denormalised
-  # mirror of the Item :read grants in app/models/ability.rb - keep the two in step. The
-  # consistency is pinned by spec/features/search_authorisation_consistency_spec.rb.
+  # Single field holding the deduped union of user ids allowed to see a private item. Consumed by
+  # HasSearch#visibility_clauses to filter search results. This is the denormalised mirror of the
+  # Item :read grants in app/models/ability.rb - keep the two in step (see access_user_ids in
+  # search_data). The consistency is pinned by spec/features/search_authorisation_consistency_spec.rb.
   def self.search_user_fields
-    %i[admin_ids user_ids collection_user_ids collection_admin_ids]
+    %i[access_user_ids]
   end
 
   def self.search_agg_fields
@@ -339,6 +339,12 @@ class Item < ApplicationRecord
         }
 
   def search_data
+    # Computed once and reused for both the facet fields and the access_user_ids union below.
+    admin_ids = admins.map(&:id)
+    user_ids = users.map(&:id)
+    collection_admin_ids = collection.admins.map(&:id)
+    collection_user_ids = collection.users.map(&:id)
+
     data = {
       # Full text plus advanced search
       entity_type: 'Item',
@@ -398,11 +404,14 @@ class Item < ApplicationRecord
       university_id:,
       access_condition_id:,
       discourse_type_id:,
-      admin_ids: admins.map(&:id).uniq,
+      # admin_ids/user_ids survive as the advanced-search "Edit access"/"Read/Download access" facets
+      # (see search_filter_fields).
+      admin_ids: admin_ids.uniq,
       agent_ids: item_agents.map(&:user_id).uniq,
-      user_ids: users.map(&:id).uniq,
-      collection_user_ids: collection.users.map(&:id).uniq,
-      collection_admin_ids: collection.admins.map(&:id).uniq,
+      user_ids: user_ids.uniq,
+      # Read-visibility union: item editors + read-grantees + collection editors + read-grantees.
+      # Consumed by HasSearch#visibility_clauses.
+      access_user_ids: (admin_ids + user_ids + collection_admin_ids + collection_user_ids).uniq,
       originated_on:,
       metadata_exportable:,
       born_digital:,

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,0 +1,68 @@
+# ## Schema Information
+#
+# Table name: `permissions`
+# Database name: `primary`
+#
+# ### Columns
+#
+# Name                  | Type               | Attributes
+# --------------------- | ------------------ | ---------------------------
+# **`id`**              | `integer`          | `not null, primary key`
+# **`grantable_type`**  | `string(255)`      | `not null`
+# **`level`**           | `string(255)`      | `not null`
+# **`created_at`**      | `datetime`         | `not null`
+# **`updated_at`**      | `datetime`         | `not null`
+# **`grantable_id`**    | `integer`          | `not null`
+# **`user_id`**         | `bigint`           | `not null`
+#
+# ### Indexes
+#
+# * `index_permissions_on_grantable_and_user_and_level` (_unique_):
+#     * **`grantable_type`**
+#     * **`grantable_id`**
+#     * **`user_id`**
+#     * **`level`**
+# * `index_permissions_on_user_id`:
+#     * **`user_id`**
+#
+# ### Foreign Keys
+#
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`user_id => users.id`**
+#
+class Permission < ApplicationRecord
+  include RejectsContactGrants
+
+  has_paper_trail
+
+  # grantable is polymorphic over Collection and Item; level maps the four old membership
+  # tables onto one shape: collection_admins/item_admins -> edit, collection_users/item_users -> read.
+  belongs_to :user
+  belongs_to :grantable, polymorphic: true
+
+  enum :level, { read: 'read', edit: 'edit' }
+
+  validates :level, presence: true
+  validates :user_id, uniqueness: { scope: %i[grantable_type grantable_id level] }
+
+  after_commit :reindex_search_documents
+
+  private
+
+  # A grant is denormalised into the search index of its subject, the records that cascade
+  # from it, and their essences, so all three must be reindexed when access changes. Mirrors
+  # the scope of the four old membership models: a collection grant reindexes the collection,
+  # its items and its essences; an item grant reindexes the item, its collection and its essences.
+  def reindex_search_documents
+    case grantable
+    when Collection
+      grantable.reindex(mode: :async)
+      grantable.items.reindex(mode: :async)
+      grantable.essences.reindex(mode: :async)
+    when Item
+      grantable.reindex(mode: :async)
+      grantable.collection.reindex(mode: :async)
+      grantable.essences.reindex(mode: :async)
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,13 +83,9 @@ class User < ApplicationRecord
 
   scope :alpha, -> { order(:first_name, :last_name) }
 
-  has_many :collection_admins
-  has_many :collections, through: :collection_admins, dependent: :destroy
-
-  has_many :item_admins
-  has_many :items, through: :item_admins, dependent: :destroy
-
-  has_many :item_users
+  # A user's access grants live in the polymorphic permissions table; the database foreign key
+  # (permissions.user_id, ON DELETE cascade) removes them when the user is destroyed.
+  has_many :permissions, dependent: :destroy
 
   has_many :item_agents, dependent: :destroy
 

--- a/app/services/collection_destruction_service.rb
+++ b/app/services/collection_destruction_service.rb
@@ -6,11 +6,12 @@ class CollectionDestructionService
 
     # delete_all is efficient but skips ActiveRecord callbacks, so the `dependent: :destroy`
     # cleanup on Item/Essence never fires. Remove the dependent rows ourselves to avoid orphans:
-    # the denormalised entity rows and the items' edit/read-only membership grants.
+    # the denormalised entity rows and the items' and collection's access grants. Permission has
+    # no DB foreign key to its polymorphic grantable, so deleting items would otherwise strand
+    # their grant rows.
     Essence.where(id: essence_ids).delete_all
-    ItemAdmin.where(item_id: item_ids).delete_all
-    ItemUser.where(item_id: item_ids).delete_all
-    CollectionUser.where(collection_id: collection.id).delete_all
+    Permission.where(grantable_type: 'Item', grantable_id: item_ids).delete_all
+    Permission.where(grantable_type: 'Collection', grantable_id: collection.id).delete_all
     deleted_items_count = Item.where(collection_id: collection.id).delete_all
     Entity.where(entity_type: 'Essence', entity_id: essence_ids).delete_all
     Entity.where(entity_type: 'Item', entity_id: item_ids).delete_all

--- a/app/services/permissions/backfill.rb
+++ b/app/services/permissions/backfill.rb
@@ -1,0 +1,59 @@
+module Permissions
+  # Deploy-time backfill that fills the polymorphic `permissions` table from the four old
+  # membership tables, collapsing them onto the single (user, grantable, level) shape:
+  #
+  #   * collection_admins -> Collection edit
+  #   * collection_users  -> Collection read
+  #   * item_admins       -> Item edit
+  #   * item_users        -> Item read
+  #
+  # Contact-only users are skipped defensively so no contaminated grant is re-introduced — the
+  # four old tables predate the contact-grant guard and may still hold such rows.
+  #
+  # Idempotent: only rows not already present in `permissions` are inserted, and the unique index
+  # guards against any racing duplicate. Inserts go through `insert_all`, which bypasses model
+  # callbacks and paper_trail; the whole run is wrapped in `Searchkick.callbacks(false)` so no
+  # per-row reindex fires. The bulk reindex is a separate, explicit deploy step.
+  class Backfill
+    # Ordered so reports read collection-then-item, edit-then-read-only, matching the auditors.
+    SOURCES = {
+      collection_edit: { model: CollectionAdmin, grantable_type: 'Collection', foreign_key: :collection_id, level: 'edit' },
+      collection_read_only: { model: CollectionUser, grantable_type: 'Collection', foreign_key: :collection_id, level: 'read' },
+      item_edit: { model: ItemAdmin, grantable_type: 'Item', foreign_key: :item_id, level: 'edit' },
+      item_read_only: { model: ItemUser, grantable_type: 'Item', foreign_key: :item_id, level: 'read' }
+    }.freeze
+
+    def call
+      Searchkick.callbacks(false) do
+        counts = SOURCES.transform_values { |config| backfill(config) }
+        counts.merge(total: counts.values.sum)
+      end
+    end
+
+    private
+
+    def contact_only_users
+      User.where(contact_only: true).select(:id)
+    end
+
+    # Inserts only the source rows that don't already exist as a permission, so re-running grants
+    # nothing new. Returns the number of rows actually inserted.
+    def backfill(config)
+      candidates = config[:model]
+                   .where.not(user_id: contact_only_users)
+                   .pluck(config[:foreign_key], :user_id)
+                   .map { |grantable_id, user_id| { grantable_type: config[:grantable_type], grantable_id:, user_id:, level: config[:level] } }
+      return 0 if candidates.empty?
+
+      existing = Permission.where(grantable_type: config[:grantable_type], level: config[:level])
+                           .where(grantable_id: candidates.map { |row| row[:grantable_id] })
+                           .pluck(:grantable_id, :user_id)
+                           .to_set
+      fresh = candidates.reject { |row| existing.include?([row[:grantable_id], row[:user_id]]) }
+      return 0 if fresh.empty?
+
+      Permission.insert_all(fresh)
+      fresh.size
+    end
+  end
+end

--- a/app/services/permissions/item_edit_dedup_auditor.rb
+++ b/app/services/permissions/item_edit_dedup_auditor.rb
@@ -1,0 +1,56 @@
+module Permissions
+  # Item-edit de-dup auditor. After backfill the `permissions` table holds an item-edit grant for
+  # every historical `item_admins` row, and the large majority of those duplicate a collection-edit
+  # grant the same user already holds on the item's collection. Those duplicates were manufactured
+  # by the now-removed item prefill / spreadsheet copy; since Phase 1 made collection-edit cascade
+  # to items, they are dead redundant rows.
+  #
+  # `report` counts exactly the redundant item-edit grants. `cleanup` deletes only those,
+  # *preserving* genuine item-only edit grants — an item-edit grant whose user holds no
+  # collection-edit grant on that item's collection is real access and is left untouched. The two
+  # are separate methods (and separate rake tasks) so the destructive step is confirmed on its own,
+  # following the `Permissions::ContactGrantAuditor` report/cleanup shape.
+  #
+  # Redundancy is resolved in Ruby from two cheap plucks rather than a self-referential DELETE
+  # subquery, which MySQL forbids. Deletes go through `delete_all`, skipping model callbacks and
+  # paper_trail; the rake wrapper additionally runs inside `Searchkick.callbacks(false)` so the
+  # bulk reindex stays an explicit, separate deploy step.
+  class ItemEditDedupAuditor
+    DELETE_BATCH_SIZE = 10_000
+
+    def report
+      { redundant_item_edit_grants: redundant_ids.size }
+    end
+
+    # Deletes only the redundant item-edit grants. Returns the number of rows deleted.
+    def cleanup
+      deleted = redundant_ids.each_slice(DELETE_BATCH_SIZE).sum { |ids| Permission.where(id: ids).delete_all }
+      { deleted_item_edit_grants: deleted }
+    end
+
+    private
+
+    # Ids of item-edit grants whose user already holds a collection-edit grant on the item's
+    # collection. An item-edit grant with no matching collection-edit — or one pointing at a
+    # deleted item — is genuine (or orphan) access and is deliberately excluded here.
+    def redundant_ids
+      collection_edit_pairs = Permission.where(grantable_type: 'Collection', level: 'edit')
+                                        .pluck(:grantable_id, :user_id)
+                                        .to_set
+      return [] if collection_edit_pairs.empty?
+
+      item_collection = Item.where(id: item_edit_grants.select(:grantable_id))
+                            .pluck(:id, :collection_id)
+                            .to_h
+
+      item_edit_grants.pluck(:id, :grantable_id, :user_id).filter_map do |id, item_id, user_id|
+        collection_id = item_collection[item_id]
+        id if collection_id && collection_edit_pairs.include?([collection_id, user_id])
+      end
+    end
+
+    def item_edit_grants
+      Permission.where(grantable_type: 'Item', level: 'edit')
+    end
+  end
+end

--- a/app/services/unconfirmed_users_service.rb
+++ b/app/services/unconfirmed_users_service.rb
@@ -148,14 +148,14 @@ class UnconfirmedUsersService
     # Collection references
     referenced_ids.merge(Collection.pluck(:collector_id))
     referenced_ids.merge(Collection.where.not(operator_id: nil).pluck(:operator_id))
-    referenced_ids.merge(CollectionAdmin.pluck(:user_id))
 
     # Item references
     referenced_ids.merge(Item.pluck(:collector_id))
     referenced_ids.merge(Item.where.not(operator_id: nil).pluck(:operator_id))
-    referenced_ids.merge(ItemAdmin.pluck(:user_id))
     referenced_ids.merge(ItemAgent.pluck(:user_id))
-    referenced_ids.merge(ItemUser.pluck(:user_id))
+
+    # Access grant references (collection/item, read/edit) all live in the permissions table
+    referenced_ids.merge(Permission.pluck(:user_id))
 
     # Comment references
     referenced_ids.merge(Comment.pluck(:owner_id))
@@ -184,12 +184,10 @@ class UnconfirmedUsersService
     references = []
     references << 'Collection collector' if Collection.where(collector_id: user_id).exists?
     references << 'Collection operator' if Collection.where(operator_id: user_id).exists?
-    references << 'CollectionAdmin' if CollectionAdmin.where(user_id: user_id).exists?
     references << 'Item collector' if Item.where(collector_id: user_id).exists?
     references << 'Item operator' if Item.where(operator_id: user_id).exists?
-    references << 'ItemAdmin' if ItemAdmin.where(user_id: user_id).exists?
     references << 'ItemAgent' if ItemAgent.where(user_id: user_id).exists?
-    references << 'ItemUser' if ItemUser.where(user_id: user_id).exists?
+    references << 'Permission' if Permission.where(user_id: user_id).exists?
     references << 'Comment owner' if Comment.where(owner_id: user_id).exists?
     references << 'Rights transferred to' if User.where(rights_transferred_to_id: user_id).exists?
     references << 'Download' if Download.where(user_id: user_id).exists?

--- a/app/services/user_merger_service.rb
+++ b/app/services/user_merger_service.rb
@@ -25,8 +25,21 @@ class UserMergerService
     # set all fields referencing old duplicates to point to new primary user
     Item.where(collector_id: dup_ids).update_all(collector_id: @user.id)
     Item.where(operator_id: dup_ids).update_all(operator_id: @user.id)
-    ItemUser.where(user_id: dup_ids).update_all(user_id: @user.id)
-    ItemAdmin.where(user_id: dup_ids).update_all(user_id: @user.id)
+    # Access grants (collection/item, read/edit) now all live in the polymorphic permissions
+    # table, so one pass moves every grant the duplicates held onto the primary. A grant the
+    # primary already holds is dropped rather than duplicated, so the (user, grantable, level)
+    # unique index is never violated. update_columns/delete skip callbacks, matching the old
+    # bulk update_all (a single reindex follows a merge, as before).
+    held = Permission.where(user_id: @user.id).pluck(:grantable_type, :grantable_id, :level).to_set
+    Permission.where(user_id: dup_ids).find_each do |permission|
+      key = [permission.grantable_type, permission.grantable_id, permission.level]
+      if held.include?(key)
+        permission.delete
+      else
+        permission.update_columns(user_id: @user.id)
+        held << key
+      end
+    end
     ItemAgent.where(user_id: dup_ids).update_all(user_id: @user.id)
   end
 end

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -331,6 +331,9 @@
             %small Append
             = f.check_box :bulk_edit_append_admin_comment
 
+  - unless params[:action] == 'bulk_edit'
+    = render 'inherited_access'
+
   - if params[:action] == 'bulk_edit'
     %fieldset
       %legend Bulk Delete

--- a/app/views/items/_inherited_access.html.haml
+++ b/app/views/items/_inherited_access.html.haml
@@ -1,0 +1,24 @@
+-# Read-only view of the access this item inherits from its collection. Collection editors (edit-level
+-# grants) and read-only grantees (read-level grants) cascade to every item automatically, so they are
+-# not item-level rows and are not editable here — the item's own pickers hold the additional grants.
+%fieldset.inherited-access
+  %legend Inherited from collection
+  %p
+    %em
+      These editors and read-only grantees are granted by the collection and apply to this item automatically.
+      They are not editable here.
+  %table.form.show
+    %tr
+      %th Collection editors
+      %td
+        - @item.collection.admins.each do |admin|
+          = admin.name
+          %br
+    %tr
+      %th Collection read/download access
+      %td
+        - @item.collection.users.each do |user|
+          = user.name
+          %br
+  - if can? :manage, @item.collection
+    %p= link_to 'Manage access on the collection', edit_collection_path(@item.collection)

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -222,6 +222,8 @@
           %th Data access narrative
           %td= h(@item.access_narrative).gsub(/\n/, '<br/>').html_safe
 
+    = render 'inherited_access'
+
   - if can? :manage, @item
     %fieldset
       %legend Archive Information

--- a/db/migrate/20260701000001_create_permissions.rb
+++ b/db/migrate/20260701000001_create_permissions.rb
@@ -1,0 +1,19 @@
+class CreatePermissions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :permissions, id: :integer do |t|
+      t.bigint :user_id, null: false
+      t.string :grantable_type, null: false
+      t.integer :grantable_id, null: false
+      t.string :level, null: false
+
+      t.timestamps
+    end
+
+    add_index :permissions, :user_id
+    add_index :permissions, %i[grantable_type grantable_id user_id level], unique: true, name: 'index_permissions_on_grantable_and_user_and_level'
+
+    # grantable is polymorphic (Collection or Item), so no database foreign key is possible;
+    # the user_id foreign key mirrors the four old membership tables (ON DELETE => cascade).
+    add_foreign_key :permissions, :users, column: :user_id, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_17_000002) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_01_000001) do
   create_table "access_conditions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.string "name"
@@ -419,6 +419,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_17_000002) do
     t.index ["access_grant_id"], name: "index_oauth_openid_requests_on_access_grant_id"
   end
 
+  create_table "permissions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "grantable_id", null: false
+    t.string "grantable_type", null: false
+    t.string "level", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["grantable_type", "grantable_id", "user_id", "level"], name: "index_permissions_on_grantable_and_user_and_level", unique: true
+    t.index ["user_id"], name: "index_permissions_on_user_id"
+  end
+
   create_table "searchjoy_conversions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "convertable_id"
     t.string "convertable_type"
@@ -519,4 +530,5 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_17_000002) do
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "users", column: "resource_owner_id"
   add_foreign_key "oauth_openid_requests", "oauth_access_grants", column: "access_grant_id", on_delete: :cascade
+  add_foreign_key "permissions", "users", on_delete: :cascade
 end

--- a/lib/nabu/spreadsheet.rb
+++ b/lib/nabu/spreadsheet.rb
@@ -43,7 +43,7 @@ module Nabu
     def parse
       coll_id = parse_coll_id
       @collection = Collection
-                    .includes(:languages, :countries, collection_admins: [:user], items: { item_admins: [:user] })
+                    .includes(:languages, :countries, :admins, items: :admins)
                     .find_by(identifier: coll_id)
       collector = parse_user
       unless collector

--- a/lib/nabu/spreadsheet.rb
+++ b/lib/nabu/spreadsheet.rb
@@ -43,7 +43,7 @@ module Nabu
     def parse
       coll_id = parse_coll_id
       @collection = Collection
-                    .includes(:languages, :countries, :admins, items: :admins)
+                    .includes(:languages, :countries)
                     .find_by(identifier: coll_id)
       collector = parse_user
       unless collector
@@ -141,7 +141,6 @@ module Nabu
         item.east_limit = @collection.east_limit
         item.access_condition_id = @collection.access_condition_id
         item.access_narrative = @collection.access_narrative
-        item.admin_ids = @collection.admin_ids
         item.title = 'PLEASE PROVIDE TITLE'
         item.description = 'PLEASE PROVIDE DESCRIPTION'
       end

--- a/lib/tasks/permissions.rake
+++ b/lib/tasks/permissions.rake
@@ -46,4 +46,27 @@ namespace :permissions do
     puts format('  %-44s %d', 'collection read-only (collection_users)', inserted.fetch(:collection_read_only))
     puts format('  %-44s %d', 'item read-only (item_users)', inserted.fetch(:item_read_only))
   end
+
+  desc 'Backfill the permissions table from the four old membership tables (idempotent; skips contacts; no reindex)'
+  task backfill: :environment do
+    inserted = Permissions::Backfill.new.call
+
+    print_section.call('Inserted permission grants from the four old membership tables:', inserted)
+  end
+
+  desc 'Report item-edit permission grants redundant against a collection-edit grant the same user holds'
+  task item_edit_dedup_report: :environment do
+    report = Searchkick.callbacks(false) { Permissions::ItemEditDedupAuditor.new.report }
+
+    puts 'Redundant item-edit grants (user already holds collection-edit on the item\'s collection):'
+    puts format('  %-44s %d', 'redundant item-edit grants', report.fetch(:redundant_item_edit_grants))
+  end
+
+  desc 'Delete only the redundant item-edit grants; genuine item-only edit grants are preserved'
+  task item_edit_dedup_cleanup: :environment do
+    deleted = Searchkick.callbacks(false) { Permissions::ItemEditDedupAuditor.new.cleanup }
+
+    puts 'Deleted redundant item-edit grants (genuine item-only edit grants preserved):'
+    puts format('  %-44s %d', 'deleted item-edit grants', deleted.fetch(:deleted_item_edit_grants))
+  end
 end

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@sentry/browser": "^10.62.0",
     "choices.js": "^11.2.3",
     "sass": "^1.101.0",
-    "tailwindcss": "^4.3.1",
+    "tailwindcss": "^4.3.2",
     "uuid": "^14.0.1"
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^1.101.0
         version: 1.101.0
       tailwindcss:
-        specifier: ^4.3.1
-        version: 4.3.1
+        specifier: ^4.3.2
+        version: 4.3.2
       uuid:
         specifier: ^14.0.1
         version: 14.0.1
@@ -72,7 +72,7 @@ importers:
         version: 30.4.2(@types/node@26.0.1)(ts-node@10.9.2(@types/node@26.0.1)(typescript@6.0.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.11(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@26.0.1)(ts-node@10.9.2(@types/node@26.0.1)(typescript@6.0.3)))(typescript@6.0.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@26.0.1)(ts-node@10.9.2(@types/node@26.0.1)(typescript@6.0.3)))(typescript@6.0.3)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@26.0.1)(typescript@6.0.3)
@@ -98,10 +98,6 @@ packages:
       - jsonschema
       - semver
 
-  '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
@@ -110,16 +106,8 @@ packages:
     resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.29.0':
-    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/core@7.29.7':
     resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/generator@7.29.1':
-    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/generator@7.29.7':
@@ -144,24 +132,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-plugin-utils@7.28.6':
-    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-plugin-utils@7.29.7':
     resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.29.7':
@@ -175,11 +151,6 @@ packages:
   '@babel/helpers@7.29.7':
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.29.3':
-    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
@@ -283,10 +254,6 @@ packages:
 
   '@babel/traverse@7.29.7':
     resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -848,9 +815,6 @@ packages:
   '@types/jest@30.0.0':
     resolution: {integrity: sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==}
 
-  '@types/node@24.12.0':
-    resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
-
   '@types/node@26.0.1':
     resolution: {integrity: sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==}
 
@@ -1236,8 +1200,8 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  electron-to-chromium@1.5.380:
-    resolution: {integrity: sha512-W6d5AbuEoRayO447cqrg6lKJIlscgRnnxOZl/08kfV71BQDoEBC7Wwis68z87LjyK6f4kWyTaubuDbhHKrZkbA==}
+  electron-to-chromium@1.5.381:
+    resolution: {integrity: sha512-n9Wa6yB+vDsGuA8AKbl/0z7HbvWqt5jxIdvr1IUicd0ryPrk7/xzwqLv8D9AbbvZ6avVNtXYLTfmgFHkwkyelg==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -1812,11 +1776,6 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.8.1:
-    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
@@ -1913,8 +1872,8 @@ packages:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  tailwindcss@4.3.1:
-    resolution: {integrity: sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==}
+  tailwindcss@4.3.2:
+    resolution: {integrity: sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==}
 
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
@@ -1988,9 +1947,6 @@ packages:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
-
-  undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
@@ -2079,12 +2035,6 @@ snapshots:
 
   '@aws-cdk/cloud-assembly-schema@54.5.0': {}
 
-  '@babel/code-frame@7.29.0':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -2092,26 +2042,6 @@ snapshots:
       picocolors: 1.1.1
 
   '@babel/compat-data@7.29.7': {}
-
-  '@babel/core@7.29.0':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.7
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0)
-      '@babel/helpers': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
-      '@babel/types': 7.29.7
-      '@jridgewell/remapping': 2.3.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/core@7.29.7':
     dependencies:
@@ -2132,14 +2062,6 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/generator@7.29.1':
-    dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.1.0
 
   '@babel/generator@7.29.7':
     dependencies:
@@ -2166,15 +2088,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.29.7
-      '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -2184,15 +2097,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-plugin-utils@7.28.6': {}
-
   '@babel/helper-plugin-utils@7.29.7': {}
 
-  '@babel/helper-string-parser@7.27.1': {}
-
   '@babel/helper-string-parser@7.29.7': {}
-
-  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
@@ -2203,188 +2110,94 @@ snapshots:
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/parser@7.29.3':
-    dependencies:
-      '@babel/types': 7.29.0
-
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
-  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-    optional: true
 
-  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-    optional: true
 
-  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/template@7.29.7':
     dependencies:
@@ -2403,11 +2216,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.29.0':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.7':
     dependencies:
@@ -2665,7 +2473,7 @@ snapshots:
 
   '@jest/pattern@30.4.0':
     dependencies:
-      '@types/node': 24.12.0
+      '@types/node': 26.0.1
       jest-regex-util: 30.4.0
 
   '@jest/reporters@30.4.1':
@@ -2752,7 +2560,7 @@ snapshots:
       '@jest/schemas': 30.4.1
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.12.0
+      '@types/node': 26.0.1
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -2964,10 +2772,6 @@ snapshots:
       expect: 30.4.1
       pretty-format: 30.4.1
 
-  '@types/node@24.12.0':
-    dependencies:
-      undici-types: 7.16.0
-
   '@types/node@26.0.1':
     dependencies:
       undici-types: 8.3.0
@@ -3100,19 +2904,6 @@ snapshots:
 
   aws-cdk@2.1128.1: {}
 
-  babel-jest@30.4.1(@babel/core@7.29.0):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/transform': 30.4.1
-      '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 7.0.1
-      babel-preset-jest: 30.4.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - supports-color
-
   babel-jest@30.4.1(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
@@ -3125,7 +2916,6 @@ snapshots:
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   babel-plugin-istanbul@7.0.1:
     dependencies:
@@ -3140,25 +2930,6 @@ snapshots:
   babel-plugin-jest-hoist@30.4.0:
     dependencies:
       '@types/babel__core': 7.20.5
-
-  babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.0):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
 
   babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.7):
     dependencies:
@@ -3178,20 +2949,12 @@ snapshots:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7)
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.7)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.7)
-    optional: true
-
-  babel-preset-jest@30.4.0(@babel/core@7.29.0):
-    dependencies:
-      '@babel/core': 7.29.0
-      babel-plugin-jest-hoist: 30.4.0
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
 
   babel-preset-jest@30.4.0(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
       babel-plugin-jest-hoist: 30.4.0
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
-    optional: true
 
   balanced-match@1.0.2: {}
 
@@ -3210,7 +2973,7 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.10.40
       caniuse-lite: 1.0.30001799
-      electron-to-chromium: 1.5.380
+      electron-to-chromium: 1.5.381
       node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
@@ -3309,7 +3072,7 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  electron-to-chromium@1.5.380: {}
+  electron-to-chromium@1.5.381: {}
 
   emittery@0.13.1: {}
 
@@ -3611,12 +3374,12 @@ snapshots:
 
   jest-config@30.4.2(@types/node@26.0.1)(ts-node@10.9.2(@types/node@26.0.1)(typescript@6.0.3)):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@jest/get-type': 30.1.0
       '@jest/pattern': 30.4.0
       '@jest/test-sequencer': 30.4.1
       '@jest/types': 30.4.1
-      babel-jest: 30.4.1(@babel/core@7.29.0)
+      babel-jest: 30.4.1(@babel/core@7.29.7)
       chalk: 4.1.2
       ci-info: 4.4.0
       deepmerge: 4.3.1
@@ -3673,7 +3436,7 @@ snapshots:
   jest-haste-map@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 24.12.0
+      '@types/node': 26.0.1
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -3699,7 +3462,7 @@ snapshots:
 
   jest-message-util@30.4.1:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@jest/types': 30.4.1
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
@@ -3796,17 +3559,17 @@ snapshots:
 
   jest-snapshot@30.4.1:
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
-      '@babel/types': 7.29.0
+      '@babel/core': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.7)
+      '@babel/types': 7.29.7
       '@jest/expect-utils': 30.4.1
       '@jest/get-type': 30.1.0
       '@jest/snapshot-utils': 30.4.1
       '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
       chalk: 4.1.2
       expect: 30.4.1
       graceful-fs: 4.2.11
@@ -3815,7 +3578,7 @@ snapshots:
       jest-message-util: 30.4.1
       jest-util: 30.4.1
       pretty-format: 30.4.1
-      semver: 7.8.1
+      semver: 7.8.5
       synckit: 0.11.12
     transitivePeerDependencies:
       - supports-color
@@ -3823,7 +3586,7 @@ snapshots:
   jest-util@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 24.12.0
+      '@types/node': 26.0.1
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -3851,7 +3614,7 @@ snapshots:
 
   jest-worker@30.4.1:
     dependencies:
-      '@types/node': 24.12.0
+      '@types/node': 26.0.1
       '@ungap/structured-clone': 1.3.2
       jest-util: 30.4.1
       merge-stream: 2.0.0
@@ -3903,7 +3666,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.8.1
+      semver: 7.8.5
 
   make-error@1.3.6: {}
 
@@ -3978,7 +3741,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -4053,8 +3816,6 @@ snapshots:
       '@parcel/watcher': 2.5.6
 
   semver@6.3.1: {}
-
-  semver@7.8.1: {}
 
   semver@7.8.5: {}
 
@@ -4139,7 +3900,7 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.2.9
 
-  tailwindcss@4.3.1: {}
+  tailwindcss@4.3.2: {}
 
   test-exclude@6.0.0:
     dependencies:
@@ -4149,7 +3910,7 @@ snapshots:
 
   tmpl@1.0.5: {}
 
-  ts-jest@29.4.11(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@26.0.1)(ts-node@10.9.2(@types/node@26.0.1)(typescript@6.0.3)))(typescript@6.0.3):
+  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@26.0.1)(ts-node@10.9.2(@types/node@26.0.1)(typescript@6.0.3)))(typescript@6.0.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -4158,12 +3919,12 @@ snapshots:
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.8.1
+      semver: 7.8.5
       type-fest: 4.41.0
       typescript: 6.0.3
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
       babel-jest: 30.4.1(@babel/core@7.29.7)
@@ -4201,8 +3962,6 @@ snapshots:
 
   uglify-js@3.19.3:
     optional: true
-
-  undici-types@7.16.0: {}
 
   undici-types@8.3.0: {}
 

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -9,8 +9,8 @@ describe CollectionsController, type: :controller do
   let(:collection) do
     create(
       :collection,
-      collection_admins: [CollectionAdmin.new(user: editor)],
-      collection_users: [CollectionUser.new(user: grantee)]
+      admins: [editor],
+      users: [grantee]
     )
   end
 

--- a/spec/controllers/essences_controller_spec.rb
+++ b/spec/controllers/essences_controller_spec.rb
@@ -13,7 +13,7 @@ describe EssencesController, type: :controller do
 
   before do
     # allow test user to access everything
-    item.item_users << ItemUser.new({ item: item, user: user })
+    item.users << user
   end
 
   context 'when not logged in' do

--- a/spec/controllers/item_annotations_controller_spec.rb
+++ b/spec/controllers/item_annotations_controller_spec.rb
@@ -10,7 +10,7 @@ describe ItemAnnotationsController, type: :controller do
 
   let(:base_params) { { collection_id: collection.identifier, item_id: item.identifier } }
 
-  before { item.item_admins << ItemAdmin.new(user: user) }
+  before { item.admins << user }
 
   context 'when not logged in' do
     it 'redirects from show' do

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -67,6 +67,20 @@ describe ItemsController, type: :controller do
           expect(response).to render_template(:new)
         end
       end
+
+      context 'in a collection that has an editor' do
+        before do
+          collection.admins << create(:user)
+          sign_in(manager, scope: :user)
+        end
+
+        it 'does not copy the collection editor down as an item-edit grant' do
+          post :create, params: { collection_id: collection.identifier, item: { identifier: 'newitem', title: 'New item title', description: 'New item description' } }
+          created = collection.items.find_by(identifier: 'newitem')
+          expect(created).to be_present
+          expect(created.admins).to be_empty
+        end
+      end
     end
 
     context 'when destroying an item' do

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -12,7 +12,7 @@ describe ItemsController, type: :controller do
     collection: collection,
     access_condition: AccessCondition.new({ name: 'Open (subject to agreeing to PDSC access conditions)' }),
     subject_languages: subject_languages,
-    item_users: [ItemUser.new({ user: user })]
+    users: [user]
   )}
   let(:private_item) { create(:item, collection: collection, private: true) }
   let(:essence) { create(:sound_essence) }
@@ -165,8 +165,8 @@ describe ItemsController, type: :controller do
       create(
         :item,
         collection: collection,
-        item_admins: [ItemAdmin.new(user: editor)],
-        item_users: [ItemUser.new(user: grantee)]
+        admins: [editor],
+        users: [grantee]
       )
     end
     let(:update_params) do

--- a/spec/features/items_inherited_access_spec.rb
+++ b/spec/features/items_inherited_access_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+# Slice 6 of Permissions Phase 2: the item show/edit views gain a read-only "Inherited from
+# collection" block. With the item-edit prefill removed, a collection's editors are no longer
+# copied down as item-level rows, so the block makes it obvious which access cascades from the
+# collection. It never creates or alters an item-level Permission.
+describe 'Item inherited-from-collection access' do
+  let(:admin_user) { create(:admin_user) }
+  let(:collection_editor) { create(:user, first_name: 'Edith', last_name: 'Editor') }
+  let(:collection_reader) { create(:user, first_name: 'Reba', last_name: 'Reader') }
+  let(:collection) { create(:collection) }
+  let(:item) { create(:item, collection:) }
+
+  before do
+    collection.admins << collection_editor
+    collection.users << collection_reader
+  end
+
+  def inherited_block(user, path)
+    sign_in user
+    visit path
+    find('fieldset.inherited-access')
+  end
+
+  describe 'item show' do
+    it "lists the collection's editors and read grantees" do
+      block = inherited_block(admin_user, collection_item_path(collection, item))
+      aggregate_failures do
+        expect(block).to have_text(collection_editor.name)
+        expect(block).to have_text(collection_reader.name)
+      end
+    end
+
+    it 'shows the manage-on-the-collection link to users who can manage the collection' do
+      block = inherited_block(admin_user, collection_item_path(collection, item))
+      aggregate_failures do
+        expect(block).to have_text('Inherited from collection')
+        expect(block).to have_link('Manage access on the collection', href: edit_collection_path(collection))
+      end
+    end
+
+    it 'hides the manage-on-the-collection link from users who cannot manage the collection' do
+      block = inherited_block(collection_editor, collection_item_path(collection, item))
+      aggregate_failures do
+        expect(block).to have_text(collection_editor.name)
+        expect(block).to have_no_link('Manage access on the collection')
+      end
+    end
+
+    it 'does not create any item-level Permission for the inherited grantees' do
+      inherited_block(admin_user, collection_item_path(collection, item))
+      aggregate_failures do
+        expect(item.reload.admins).to be_empty
+        expect(item.users).to be_empty
+      end
+    end
+  end
+
+  describe 'item edit' do
+    it "renders the same 'Inherited from collection' block in edit mode" do
+      block = inherited_block(admin_user, edit_collection_item_path(collection, item))
+      aggregate_failures do
+        expect(block).to have_text(collection_editor.name)
+        expect(block).to have_link('Manage access on the collection', href: edit_collection_path(collection))
+      end
+    end
+  end
+end

--- a/spec/features/search_access_revocation_spec.rb
+++ b/spec/features/search_access_revocation_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
-# Regression coverage for the denormalised permission fields in the search indexes.
-# Collection, Item and Essence search documents each embed the ids of the users allowed to
-# see them (user_ids, admin_ids, collection_user_ids, item_user_ids, ...). When a grant is
-# added or removed the affected documents must be reindexed, otherwise a revoked user keeps
-# finding private records via search. The reindex is driven by Permission#reindex_search_documents.
+# Regression coverage for the denormalised access_user_ids union in the search indexes.
+# Collection, Item and Essence search documents each embed a single access_user_ids field holding
+# the ids of everyone allowed to see them. When a grant is added or removed the affected documents
+# must be reindexed, otherwise a revoked user keeps finding private records via search. The reindex
+# is driven by Permission#reindex_search_documents.
 describe 'Search visibility when access is granted and revoked', :search do
   let!(:user) { create(:user) }
   let!(:collection) { create(:collection, :reindex, identifier: 'PRIVCOLL', private: true) }
@@ -34,8 +34,8 @@ describe 'Search visibility when access is granted and revoked', :search do
     refresh_search_indexes
   end
 
-  # A collection user is denormalised onto the collection (user_ids) and every item in it
-  # (collection_user_ids), so both indexes must follow the grant.
+  # A collection read grant lands in the access_user_ids union of the collection and every item in
+  # it (and their essences), so all those indexes must follow the grant.
   describe 'a collection user grant' do
     context 'when no grant exists' do
       before { visit search_collections_path }
@@ -85,7 +85,7 @@ describe 'Search visibility when access is granted and revoked', :search do
     end
   end
 
-  # An item user is denormalised onto the item (user_ids) and its collection (item_user_ids).
+  # An item read grant lands in the access_user_ids union of the item and its collection.
   describe 'an item user grant' do
     context 'when no grant exists' do
       before { visit search_items_path }

--- a/spec/features/search_access_revocation_spec.rb
+++ b/spec/features/search_access_revocation_spec.rb
@@ -4,8 +4,7 @@ require 'rails_helper'
 # Collection, Item and Essence search documents each embed the ids of the users allowed to
 # see them (user_ids, admin_ids, collection_user_ids, item_user_ids, ...). When a grant is
 # added or removed the affected documents must be reindexed, otherwise a revoked user keeps
-# finding private records via search. The reindex is driven by
-# CollectionUser/CollectionAdmin/ItemUser/ItemAdmin#reindex_search_documents.
+# finding private records via search. The reindex is driven by Permission#reindex_search_documents.
 describe 'Search visibility when access is granted and revoked', :search do
   let!(:user) { create(:user) }
   let!(:collection) { create(:collection, :reindex, identifier: 'PRIVCOLL', private: true) }
@@ -22,14 +21,14 @@ describe 'Search visibility when access is granted and revoked', :search do
   end
 
   def grant_then_revoke_collection_user
-    collection_user = CollectionUser.create!(collection:, user:)
+    collection_user = Permission.create!(grantable: collection, user:, level: :read)
     refresh_search_indexes
     collection_user.destroy!
     refresh_search_indexes
   end
 
   def grant_then_revoke_item_user
-    item_user = ItemUser.create!(item:, user:)
+    item_user = Permission.create!(grantable: item, user:, level: :read)
     refresh_search_indexes
     item_user.destroy!
     refresh_search_indexes
@@ -48,7 +47,7 @@ describe 'Search visibility when access is granted and revoked', :search do
 
     context 'when access has been granted' do
       before do
-        CollectionUser.create!(collection:, user:)
+        Permission.create!(grantable: collection, user:, level: :read)
         refresh_search_indexes
       end
 
@@ -98,7 +97,7 @@ describe 'Search visibility when access is granted and revoked', :search do
 
     context 'when access has been granted' do
       before do
-        ItemUser.create!(item:, user:)
+        Permission.create!(grantable: item, user:, level: :read)
         refresh_search_indexes
       end
 

--- a/spec/features/search_authorisation_consistency_spec.rb
+++ b/spec/features/search_authorisation_consistency_spec.rb
@@ -35,18 +35,18 @@ describe 'Search/Ability authorisation consistency', :search do
 
   # Every relationship that ability.rb grants :read on a private Item through.
   item_grants = {
-    'item admin' => ->(item, user) { ItemAdmin.create!(item:, user:) },
-    'item user' => ->(item, user) { ItemUser.create!(item:, user:) },
-    'collection user' => ->(item, user) { CollectionUser.create!(collection: item.collection, user:) },
-    'collection admin' => ->(item, user) { CollectionAdmin.create!(collection: item.collection, user:) }
+    'item admin' => ->(item, user) { Permission.create!(grantable: item, user:, level: :edit) },
+    'item user' => ->(item, user) { Permission.create!(grantable: item, user:, level: :read) },
+    'collection user' => ->(item, user) { Permission.create!(grantable: item.collection, user:, level: :read) },
+    'collection admin' => ->(item, user) { Permission.create!(grantable: item.collection, user:, level: :edit) }
   }
 
   # Every relationship that ability.rb grants :read on a private Collection through.
   collection_grants = {
-    'collection admin' => ->(collection, user) { CollectionAdmin.create!(collection:, user:) },
-    'collection user' => ->(collection, user) { CollectionUser.create!(collection:, user:) },
-    'item admin' => ->(collection, user) { ItemAdmin.create!(item: collection.items.reload.first, user:) },
-    'item user' => ->(collection, user) { ItemUser.create!(item: collection.items.reload.first, user:) }
+    'collection admin' => ->(collection, user) { Permission.create!(grantable: collection, user:, level: :edit) },
+    'collection user' => ->(collection, user) { Permission.create!(grantable: collection, user:, level: :read) },
+    'item admin' => ->(collection, user) { Permission.create!(grantable: collection.items.reload.first, user:, level: :edit) },
+    'item user' => ->(collection, user) { Permission.create!(grantable: collection.items.reload.first, user:, level: :read) }
   }
 
   describe 'a private item' do

--- a/spec/features/search_authorisation_consistency_spec.rb
+++ b/spec/features/search_authorisation_consistency_spec.rb
@@ -4,14 +4,16 @@ require 'cancan/matchers'
 # Consistency oracle between Ability (the canonical read policy) and the search indexes.
 #
 # Ability (app/models/ability.rb) is the single source of truth for who may :read a
-# Collection or Item. The search indexes filter results separately, using denormalised
-# permission fields (admin_ids, user_ids, collection_user_ids, collection_admin_ids,
-# item_admin_ids, item_user_ids) consumed by HasSearch#visibility_clauses.
+# Collection or Item. The search indexes filter results separately, using a single denormalised
+# access_user_ids union per document (the deduped set of everyone-who-can-read) consumed by
+# HasSearch#visibility_clauses.
 #
 # Those two mechanisms must agree: every relationship that Ability says grants :read must
 # also make the record findable in search, and vice versa. This spec pins them together so
-# they cannot drift - if you add a new read grant to ability.rb, add the matching index field
-# (and a row here) or this spec fails. See the cross-reference notes in ability.rb and
+# they cannot drift - if you add a new read grant to ability.rb, extend the access_user_ids union
+# in search_data (and add a row here) or this spec fails. Each grant case below is exercised at
+# every level (item edit/read, collection edit/read) so the union is verified to mirror all four
+# read paths for items, collections and essences. See the cross-reference notes in ability.rb and
 # app/controllers/concerns/has_search.rb.
 describe 'Search/Ability authorisation consistency', :search do
   let!(:user) { create(:user) }
@@ -89,6 +91,48 @@ describe 'Search/Ability authorisation consistency', :search do
         it 'is visible in advanced item search' do
           visit_advanced_item_search
           expect(page).to have_text(item.full_identifier)
+        end
+      end
+    end
+  end
+
+  describe 'a private essence' do
+    let!(:essence) { create(:essence, item:, size: 1234) }
+
+    def refresh_essence_index
+      Essence.search_index.refresh
+    end
+
+    # No web page renders an essence search (essences are Oni-API only), so assert directly against
+    # the Essence index the same way HasSearch#visibility_clauses does: an essence is visible when it
+    # is public OR current_user is in its access_user_ids union. This pins the union to Ability's
+    # essence :read paths, which cascade from the item and collection grants.
+    def essence_visible_to?(reader)
+      Essence.search('*', where: { _or: [{ private: false }, { access_user_ids: reader.id }] }, load: false).map(&:id).include?(essence.id)
+    end
+
+    it 'is denied read by ability when there is no grant' do
+      expect(Ability.new(user)).not_to be_able_to(:read, essence)
+    end
+
+    it 'is hidden in essence search when there is no grant' do
+      refresh_essence_index
+      expect(essence_visible_to?(user)).to be(false)
+    end
+
+    item_grants.each do |relationship, grant|
+      context "when the user is a #{relationship}" do
+        before do
+          grant.call(item, user)
+          refresh_essence_index
+        end
+
+        it 'is granted read by ability' do
+          expect(Ability.new(user)).to be_able_to(:read, essence.reload)
+        end
+
+        it 'is visible in essence search' do
+          expect(essence_visible_to?(user)).to be(true)
         end
       end
     end

--- a/spec/lib/nabu/spreadsheet_spec.rb
+++ b/spec/lib/nabu/spreadsheet_spec.rb
@@ -274,5 +274,19 @@ describe Nabu::Spreadsheet do
       item_agent = item.item_agents.first
       expect(item_agent.user.contact_only).to be(true)
     end
+
+    context 'when importing into a collection that already has an editor' do
+      before do
+        collector = User.find_by(first_name: 'VKS')
+        existing = create(:collection, identifier: 'VKS', collector: collector)
+        existing.admins << create(:user)
+      end
+
+      it 'does not copy the collection editor onto each imported item' do
+        spreadsheet.parse
+
+        expect(spreadsheet.items.flat_map(&:admins)).to be_empty
+      end
+    end
   end
 end

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -1,0 +1,104 @@
+require 'rails_helper'
+
+describe Permission, type: :model do
+  let(:user) { create(:user) }
+
+  describe 'contact-grant guard (replaces the four-model version)' do
+    # Every (grantable, level) combination the four old membership tables covered.
+    %i[collection item].each do |grantable|
+      %w[read edit].each do |level|
+        context "when granting #{level} on a #{grantable}" do
+          let(:grantable_record) { create(grantable) }
+
+          it 'is valid when granted to a real user' do
+            permission = described_class.new(grantable: grantable_record, user: create(:user), level:)
+
+            expect(permission).to be_valid
+          end
+
+          it 'is invalid when granted to a contact-only user' do
+            permission = described_class.new(grantable: grantable_record, user: create(:user, :contact_only), level:)
+
+            aggregate_failures do
+              expect(permission).not_to be_valid
+              expect(permission.errors[:user]).to include('cannot be a contact-only user; contacts can be attributed but not granted access')
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe 'level enum' do
+    it 'exposes read and edit' do
+      expect(described_class.levels).to eq('read' => 'read', 'edit' => 'edit')
+    end
+
+    it 'requires a level' do
+      permission = described_class.new(grantable: create(:collection), user:)
+
+      aggregate_failures do
+        expect(permission).not_to be_valid
+        expect(permission.errors[:level]).to be_present
+      end
+    end
+  end
+
+  describe 'uniqueness' do
+    let(:collection) { create(:collection) }
+
+    it 'rejects a duplicate (user, grantable, level) grant' do
+      described_class.create!(grantable: collection, user:, level: 'edit')
+
+      expect(described_class.new(grantable: collection, user:, level: 'edit')).not_to be_valid
+    end
+
+    it 'allows the same user to hold read and edit on the same grantable' do
+      described_class.create!(grantable: collection, user:, level: 'read')
+
+      expect(described_class.new(grantable: collection, user:, level: 'edit')).to be_valid
+    end
+  end
+
+  describe 'reindex scope' do
+    it 'is registered on after_commit' do
+      expect(described_class._commit_callbacks.map(&:filter)).to include(:reindex_search_documents)
+    end
+
+    it 'reindexes a granted collection, its items and its essences' do
+      collection = create(:collection)
+      items = collection.items
+      essences = collection.essences
+      allow(collection).to receive_messages(items:, essences:)
+
+      aggregate_failures do
+        expect(collection).to receive(:reindex).with(mode: :async)
+        expect(items).to receive(:reindex).with(mode: :async)
+        expect(essences).to receive(:reindex).with(mode: :async)
+      end
+
+      described_class.new(grantable: collection, user:, level: 'edit').send(:reindex_search_documents)
+    end
+
+    it 'reindexes a granted item, its collection and its essences' do
+      item = create(:item)
+      collection = item.collection
+      essences = item.essences
+      allow(item).to receive_messages(collection:, essences:)
+
+      aggregate_failures do
+        expect(item).to receive(:reindex).with(mode: :async)
+        expect(collection).to receive(:reindex).with(mode: :async)
+        expect(essences).to receive(:reindex).with(mode: :async)
+      end
+
+      described_class.new(grantable: item, user:, level: 'edit').send(:reindex_search_documents)
+    end
+  end
+
+  describe 'paper_trail' do
+    it 'is versioned' do
+      expect(described_class.reflect_on_association(:versions)).to be_present
+    end
+  end
+end

--- a/spec/services/collection_destruction_service_spec.rb
+++ b/spec/services/collection_destruction_service_spec.rb
@@ -23,25 +23,25 @@ describe CollectionDestructionService do
   end
 
   # Regression: items are removed with delete_all, which bypasses the `dependent: :destroy`
-  # cleanup on item_admins/item_users. Combined with the collection's own collection_users
-  # read-only grants, this previously left orphaned membership/grant rows behind.
-  context 'when the collection and its items have membership grants', :no_catalog_upload do
+  # cleanup on their permissions. Combined with the collection's own grants, and because
+  # Permission has no database foreign key to its polymorphic grantable, this would otherwise
+  # leave orphaned grant rows behind.
+  context 'when the collection and its items have access grants', :no_catalog_upload do
     let(:collection) { create(:collection) }
     let(:item) { create(:item, collection:) }
     let(:grantee) { create(:user) }
 
     before do
       allow(Nabu::Catalog.instance).to receive_messages(delete_item: 0, delete_collection: 0)
-      collection.collection_users << CollectionUser.new(user: grantee)
-      item.item_admins << ItemAdmin.new(user: grantee)
-      item.item_users << ItemUser.new(user: grantee)
+      collection.users << grantee
+      item.admins << grantee
+      item.users << grantee
     end
 
-    it 'removes the items edit and read-only membership rows and the collection read-only grants' do
+    it 'removes the items edit and read-only grants and the collection grants' do
       expect(described_class.destroy(collection)[:success]).to be(true)
-      expect(ItemAdmin.where(item_id: item.id)).not_to exist
-      expect(ItemUser.where(item_id: item.id)).not_to exist
-      expect(CollectionUser.where(collection_id: collection.id)).not_to exist
+      expect(Permission.where(grantable: item)).not_to exist
+      expect(Permission.where(grantable: collection)).not_to exist
     end
   end
 end

--- a/spec/services/permissions/backfill_spec.rb
+++ b/spec/services/permissions/backfill_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+describe Permissions::Backfill do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:collection) { create(:collection) }
+  let(:item) { create(:item, collection:) }
+
+  describe '#call' do
+    it 'maps the four old membership tables onto permissions with the correct level' do
+      CollectionAdmin.create!(collection:, user:)
+      CollectionUser.create!(collection:, user: other_user)
+      ItemAdmin.create!(item:, user:)
+      ItemUser.create!(item:, user: other_user)
+
+      described_class.new.call
+
+      aggregate_failures do
+        expect(Permission.find_by(grantable: collection, user:).level).to eq('edit')
+        expect(Permission.find_by(grantable: collection, user: other_user).level).to eq('read')
+        expect(Permission.find_by(grantable: item, user:).level).to eq('edit')
+        expect(Permission.find_by(grantable: item, user: other_user).level).to eq('read')
+      end
+    end
+
+    it 'reports per-source and total inserted counts' do
+      CollectionAdmin.create!(collection:, user:)
+      ItemAdmin.create!(item:, user: other_user)
+
+      inserted = described_class.new.call
+
+      expect(inserted).to eq(collection_edit: 1, collection_read_only: 0, item_edit: 1, item_read_only: 0, total: 2)
+    end
+
+    it 'skips contact-only users so no contaminated grant is re-introduced' do
+      contact = create(:user, :contact_only)
+      # The old tables predate the contact-grant guard, so a contaminated row is inserted directly.
+      CollectionAdmin.new(collection:, user: contact).save!(validate: false)
+      ItemAdmin.new(item:, user: contact).save!(validate: false)
+
+      inserted = described_class.new.call
+
+      aggregate_failures do
+        expect(Permission.where(user: contact)).not_to exist
+        expect(inserted[:total]).to eq(0)
+      end
+    end
+
+    it 'is idempotent — re-running inserts nothing new' do
+      CollectionAdmin.create!(collection:, user:)
+      ItemUser.create!(item:, user: other_user)
+
+      described_class.new.call
+      second_run = described_class.new.call
+
+      aggregate_failures do
+        expect(second_run[:total]).to eq(0)
+        expect(Permission.count).to eq(2)
+      end
+    end
+
+    it 'leaves an existing collection-edit grant untouched while backfilling the rest' do
+      Permission.create!(grantable: collection, user:, level: 'edit')
+      CollectionAdmin.create!(collection:, user:)
+      ItemUser.create!(item:, user: other_user)
+
+      inserted = described_class.new.call
+
+      aggregate_failures do
+        expect(inserted).to eq(collection_edit: 0, collection_read_only: 0, item_edit: 0, item_read_only: 1, total: 1)
+        expect(Permission.where(grantable: collection, user:, level: 'edit').count).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/services/permissions/item_edit_dedup_auditor_spec.rb
+++ b/spec/services/permissions/item_edit_dedup_auditor_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+describe Permissions::ItemEditDedupAuditor do
+  let(:user) { create(:user) }
+  let(:collection) { create(:collection) }
+  let(:item) { create(:item, collection:) }
+
+  # An item-edit grant is redundant when the same user already holds a collection-edit grant on
+  # the item's collection — the item grant is a dead duplicate of the cascading collection grant.
+  def redundant_grant
+    Permission.create!(grantable: collection, user:, level: 'edit')
+    Permission.create!(grantable: item, user:, level: 'edit')
+  end
+
+  describe '#report' do
+    it 'counts item-edit grants redundant against a collection-edit the same user holds' do
+      redundant_grant
+
+      expect(described_class.new.report).to eq(redundant_item_edit_grants: 1)
+    end
+
+    it 'does not count a genuine item-only edit grant (user holds no collection-edit)' do
+      Permission.create!(grantable: item, user:, level: 'edit')
+
+      expect(described_class.new.report).to eq(redundant_item_edit_grants: 0)
+    end
+
+    it 'does not count an item-edit grant when another user holds the collection-edit' do
+      Permission.create!(grantable: collection, user: create(:user), level: 'edit')
+      Permission.create!(grantable: item, user:, level: 'edit')
+
+      expect(described_class.new.report).to eq(redundant_item_edit_grants: 0)
+    end
+
+    it 'does not count an item-read grant duplicated by a collection-edit' do
+      Permission.create!(grantable: collection, user:, level: 'edit')
+      Permission.create!(grantable: item, user:, level: 'read')
+
+      expect(described_class.new.report).to eq(redundant_item_edit_grants: 0)
+    end
+  end
+
+  describe '#cleanup' do
+    it 'deletes only the redundant item-edit grants' do
+      redundant_grant
+
+      deleted = described_class.new.cleanup
+
+      aggregate_failures do
+        expect(deleted).to eq(deleted_item_edit_grants: 1)
+        expect(Permission.where(grantable: item, level: 'edit')).not_to exist
+        expect(Permission.where(grantable: collection, level: 'edit')).to exist
+      end
+    end
+
+    it 'preserves a genuine item-only edit grant where the user holds no collection-edit' do
+      genuine = Permission.create!(grantable: item, user:, level: 'edit')
+
+      deleted = described_class.new.cleanup
+
+      aggregate_failures do
+        expect(deleted).to eq(deleted_item_edit_grants: 0)
+        expect(Permission.exists?(genuine.id)).to be(true)
+      end
+    end
+
+    it 'preserves an item-only editor while removing a redundant one on the same item' do
+      redundant_user = create(:user)
+      Permission.create!(grantable: collection, user: redundant_user, level: 'edit')
+      redundant = Permission.create!(grantable: item, user: redundant_user, level: 'edit')
+      genuine = Permission.create!(grantable: item, user:, level: 'edit')
+
+      deleted = described_class.new.cleanup
+
+      aggregate_failures do
+        expect(deleted).to eq(deleted_item_edit_grants: 1)
+        expect(Permission.exists?(redundant.id)).to be(false)
+        expect(Permission.exists?(genuine.id)).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Epic: #1143 (access-layer cleanup, successor to Permissions Phase 1 #1127).

This PR delivers **Permissions Phase 2** incrementally — collapsing the four
parallel membership tables (`collection_admins`, `collection_users`,
`item_admins`, `item_users`) into a single polymorphic
`Permission(user, grantable, level)` grant, and stopping the code that
manufactures redundant `item_admins` rows. It changes **how grants are stored**,
not **who can do what** — the Phase 1 authorisation behaviour is preserved.

Commits will be added slice by slice; this description tracks progress.

## Slices

- [x] **Slice 1 — Spike (#1144):** chose **rung A** (level-scoped polymorphic
  associations). `accessible_by` generates correct SQL with `grantable_type`
  injected for a polymorphic `permissions` association in nested hash
  conditions; scoped-association setters persist the correct `level`. Evidence
  on #1144. (Spike code was throwaway — not in this PR.)
- [x] **Slice 2 — Permission model + migration (#1145):** adds the polymorphic
  `permissions` table and `Permission` model (level enum, `has_paper_trail`,
  `RejectsContactGrants`, consolidated reindex callback). The four old
  tables/models stay untouched; nothing reads/writes `Permission` yet.
- [x] **Slice 3 — Rewire Ability + forms/controllers to Permission (#1146)**
- [x] **Slice 4 — Collapse search visibility to a single access_user_ids union (#1147)**
- [x] **Slice 5 — Remove item-edit prefill (#1148):** drops the `admin_ids` copy
  from `Item#prefill` and the spreadsheet importer (and the now-dead item-admin
  eager-load). Note: the `Item#prefill` copy was already inert (`||=` on a truthy
  `[]`), so the importer's direct assignment was the only live source of
  redundant rows; tests cover the single-create and bulk-import paths.
- [x] **Slice 6 — Cascaded "Inherited from collection" UI (#1149):** adds a
  read-only "Inherited from collection" block to the item show and edit views
  listing the collection's editors (`edit`-level) and read-only grantees
  (`read`-level). Purely informational — never creates or alters an item-level
  `Permission`; the "Manage access on the collection" link is gated to users who
  can manage the collection, while the list is visible to anyone who can see the
  item's access section.
- [x] **Slice 7 — Permissions backfill service + de-dup auditor (#1150):** adds
  `Permissions::Backfill` (maps the four old tables onto `permissions` with the
  correct level, skips contact-only users, idempotent, bulk `insert_all`) and
  `Permissions::ItemEditDedupAuditor` (report → separately-confirmable cleanup
  that deletes only the item-edit grants redundant against a collection-edit the
  same user holds, preserving genuine item-only edit grants), plus their rake
  tasks. Both run with reindex callbacks suppressed, leaving the single explicit
  reindex to the deploy step.
- [ ] **Slice 8 — Deploy runbook + announcement banner (#1151)**
- [ ] **Follow-up — drop the four dead membership tables (#1152)**

## Notes

- `admin_ids`/`user_ids` search params are **both** stripped-for-security (for
  non-admins) **and** a live admin "filter by editor" facet — so the Slice 4
  visibility collapse must keep those facet fields independently (documented on
  #1144).
- Admin remains the global `User.admin` boolean, never a per-record `level`.

Refs #1143 #1144 #1145 #1146 #1147 #1148 #1149 #1150