### PR TITLE
feat(catalog): write RO-Crates and deposit PDFs to crate-root keys

### DIFF
--- a/app/services/catalog_db_sync_validator_service.rb
+++ b/app/services/catalog_db_sync_validator_service.rb
@@ -58,8 +58,7 @@ class CatalogDbSyncValidatorService
       s3_files << CGI.unescape(filename)
     end
 
-    s3_files = s3_files.reject { |filename| filename.ends_with?('/ro-crate-metadata.json') }
-      .reject { |filename| filename.match?(%r{\A([^/]+)/\1-deposit\.pdf\z}) }
+    s3_files = s3_files.reject { |filename| Nabu::Catalog.instance.admin_key?(filename) }
 
     if s3_files.size != s3_files.uniq.size
       raise 'Duplicate files in S3 inventory'

--- a/app/services/catalog_db_sync_validator_service.rb
+++ b/app/services/catalog_db_sync_validator_service.rb
@@ -58,8 +58,8 @@ class CatalogDbSyncValidatorService
       s3_files << CGI.unescape(filename)
     end
 
-    s3_files = s3_files.reject { |filename| filename.ends_with?('pdsc_admin/ro-crate-metadata.json') }
-      .reject { |filename| filename.include?('/pdsc_admin/') && filename.ends_with?('-deposit.pdf') }
+    s3_files = s3_files.reject { |filename| filename.ends_with?('/ro-crate-metadata.json') }
+      .reject { |filename| filename.match?(%r{\A([^/]+)/\1-deposit\.pdf\z}) }
 
     if s3_files.size != s3_files.uniq.size
       raise 'Duplicate files in S3 inventory'

--- a/app/services/catalog_replication_validator_service.rb
+++ b/app/services/catalog_replication_validator_service.rb
@@ -48,8 +48,8 @@ class CatalogReplicationValidatorService
       new_files << file if Time.parse(last_modified) > Time.now - 1.week
     end
 
-    s3_files = s3_files.reject { |filename| filename.ends_with?('pdsc_admin/ro-crate-metadata.json') }
-      .reject { |filename| filename.starts_with?('pdsc_admin/') && filename.ends_with?('-deposit.pdf') }
+    s3_files = s3_files.reject { |filename| filename.ends_with?('/ro-crate-metadata.json') }
+      .reject { |filename| filename.match?(%r{\A([^/]+)/\1-deposit\.pdf\z}) }
 
     if s3_files.size != s3_files.uniq.size
       raise 'Duplicate files in S3 inventory'

--- a/app/services/catalog_replication_validator_service.rb
+++ b/app/services/catalog_replication_validator_service.rb
@@ -48,8 +48,7 @@ class CatalogReplicationValidatorService
       new_files << file if Time.parse(last_modified) > Time.now - 1.week
     end
 
-    s3_files = s3_files.reject { |filename| filename.ends_with?('/ro-crate-metadata.json') }
-      .reject { |filename| filename.match?(%r{\A([^/]+)/\1-deposit\.pdf\z}) }
+    s3_files = s3_files.reject { |filename| Nabu::Catalog.instance.admin_key?(filename) }
 
     if s3_files.size != s3_files.uniq.size
       raise 'Duplicate files in S3 inventory'

--- a/lib/nabu/catalog.rb
+++ b/lib/nabu/catalog.rb
@@ -136,11 +136,11 @@ module Nabu
     private
 
     def collection_admin_key(collection, filename)
-      [collection.identifier, 'pdsc_admin', filename].join('/')
+      [collection.identifier, filename].join('/')
     end
 
     def item_admin_key(item, filename)
-      [item.collection.identifier, item.identifier, 'pdsc_admin', filename].join('/')
+      [item.collection.identifier, item.identifier, filename].join('/')
     end
 
     def bucket_name

--- a/lib/nabu/catalog.rb
+++ b/lib/nabu/catalog.rb
@@ -7,6 +7,8 @@ module Nabu
     include Singleton
 
     ADMIN_ROCRATE_FILENAME = 'ro-crate-metadata.json'.freeze
+    DEPOSIT_FORM_SUFFIX = '-deposit.pdf'.freeze
+    DEPOSIT_FORM_KEY_PATTERN = %r{\A([^/]+)/\1#{Regexp.escape(DEPOSIT_FORM_SUFFIX)}\z}
 
     # S3's DeleteObjects API accepts at most 1000 keys per request.
     MAX_DELETE_KEYS = 1000
@@ -44,7 +46,15 @@ module Nabu
     end
 
     def deposit_form_key(collection)
-      collection_admin_key(collection, "#{collection.identifier}-deposit.pdf")
+      collection_admin_key(collection, "#{collection.identifier}#{DEPOSIT_FORM_SUFFIX}")
+    end
+
+    # True for the admin files nabu writes alongside essences: RO-Crate metadata
+    # at the collection/item root and the collection's deposit PDF.
+    def admin_key?(key)
+      return true if key.end_with?("/#{ADMIN_ROCRATE_FILENAME}")
+
+      key.end_with?(DEPOSIT_FORM_SUFFIX) && key.match?(DEPOSIT_FORM_KEY_PATTERN)
     end
 
     # Every key that makes up an item in the bucket: its essence files plus its admin metadata.

--- a/spec/lib/nabu/catalog_spec.rb
+++ b/spec/lib/nabu/catalog_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe Nabu::Catalog do
+  let(:catalog) { described_class.instance }
+  let(:collection) { build(:collection, identifier: 'AA1') }
+  let(:item) { build(:item, identifier: '001', collection:) }
+
+  describe '#collection_rocrate_key' do
+    it 'lives at the collection root' do
+      expect(catalog.collection_rocrate_key(collection)).to eq('AA1/ro-crate-metadata.json')
+    end
+  end
+
+  describe '#item_rocrate_key' do
+    it 'lives at the item root' do
+      expect(catalog.item_rocrate_key(item)).to eq('AA1/001/ro-crate-metadata.json')
+    end
+  end
+
+  describe '#deposit_form_key' do
+    it 'lives at the collection root, named after the collection' do
+      expect(catalog.deposit_form_key(collection)).to eq('AA1/AA1-deposit.pdf')
+    end
+  end
+end

--- a/spec/lib/nabu/catalog_spec.rb
+++ b/spec/lib/nabu/catalog_spec.rb
@@ -22,4 +22,20 @@ describe Nabu::Catalog do
       expect(catalog.deposit_form_key(collection)).to eq('AA1/AA1-deposit.pdf')
     end
   end
+
+  describe '#admin_key?' do
+    it 'recognises every admin key the builders produce' do
+      expect(catalog.admin_key?(catalog.collection_rocrate_key(collection))).to be true
+      expect(catalog.admin_key?(catalog.item_rocrate_key(item))).to be true
+      expect(catalog.admin_key?(catalog.deposit_form_key(collection))).to be true
+    end
+
+    it 'does not match essence keys' do
+      expect(catalog.admin_key?('AA1/001/recording.wav')).to be false
+    end
+
+    it 'does not match a deposit PDF named after a different collection' do
+      expect(catalog.admin_key?('AA1/BB2-deposit.pdf')).to be false
+    end
+  end
 end


### PR DESCRIPTION
Part of wayfinder map #1163, resolves #1166.

Removes the `pdsc_admin/` path segment from every key nabu writes or reads in the catalog bucket:

- Item RO-Crate: `<coll>/<item>/pdsc_admin/ro-crate-metadata.json` → `<coll>/<item>/ro-crate-metadata.json`
- Collection RO-Crate: `<coll>/pdsc_admin/ro-crate-metadata.json` → `<coll>/ro-crate-metadata.json`
- Deposit PDF: `<coll>/pdsc_admin/<coll>-deposit.pdf` → `<coll>/<coll>-deposit.pdf`

`CatalogDbSyncValidatorService` and `CatalogReplicationValidatorService` now exclude the new key shapes (`*/ro-crate-metadata.json` and `<coll>/<coll>-deposit.pdf`) instead of the `pdsc_admin` prefix, and a new spec pins the key layout.

⚠️ **Do not merge/deploy standalone.** The read path (`deposit_form_url`, admin URLs) moves with the same key builders, so this must land in step with the S3 object migration (#1168) — until objects are moved/regenerated, downloads of old-location objects would 404 after deploy.

Verified: `rubocop` clean on the changed files; `rspec spec/lib/nabu/catalog_spec.rb spec/services/item_destruction_service_spec.rb spec/services/collection_destruction_service_spec.rb spec/jobs/delete_catalog_files_job_spec.rb` — 18 examples, 0 failures. No `pdsc_admin` references remain in the repo.