### PR TITLE
fix(oni): keep RO-Crate map extents within valid longitudes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -173,6 +173,19 @@ module ApplicationHelper
     "#{Rails.application.config.oni_url}/file?id=#{URI.encode_www_form_component(repository_essence_url(collection_identifier, item_identifier, essence_filename))}"
   end
 
+  # A genuine antimeridian crossing has a non-positive east edge and unwraps into
+  # 0..360 space; east < west with a positive east edge can only be a swapped
+  # extent, so render the box the curator meant rather than longitudes beyond 360.
+  def normalised_extent(shape)
+    west = shape.west_limit
+    east = shape.east_limit
+    return [west, east] unless east < west
+    return [west, east + 360] if east <= 0
+
+    Rails.logger.warn("Swapped map extent on #{shape.class.name} #{shape.try(:id)}: west=#{west} east=#{east}")
+    [east, west]
+  end
+
   private
 
   def preloaded_select_tag(attribute, collection, label_method, default_placeholder, options = {}, multiple: false)

--- a/app/models/concerns/has_boundaries.rb
+++ b/app/models/concerns/has_boundaries.rb
@@ -2,6 +2,8 @@ module HasBoundaries
   extend ActiveSupport::Concern
 
   included do
+    validate :extent_not_swapped
+
     def boundaries
       return unless has_all_boundaries?
       OpenStruct.new(
@@ -14,6 +16,17 @@ module HasBoundaries
 
     def has_all_boundaries?
       north_limit? && south_limit? && west_limit? && east_limit?
+    end
+
+    private
+
+    # A genuine antimeridian crossing has a non-positive east edge, so east < west
+    # with both edges positive can only be a swapped extent.
+    def extent_not_swapped
+      return unless west_limit && east_limit
+      return unless east_limit < west_limit && east_limit > 0
+
+      errors.add(:east_limit, 'is west of the west limit — the extent is swapped')
     end
   end
 end

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -23,6 +23,8 @@
 #
 
 class Language < ApplicationRecord
+  include HasBoundaries
+
   has_paper_trail
 
   validates :name, presence: true

--- a/app/views/api/v1/oni/object_meta_collection.json.jb
+++ b/app/views/api/v1/oni/object_meta_collection.json.jb
@@ -38,13 +38,13 @@ end
 def collection_geometry_json(shape)
   id = "#geo-#{shape.west_limit},#{shape.south_limit}-#{shape.east_limit},#{shape.north_limit}"
 
-  east_limit = shape.east_limit < shape.west_limit ? shape.east_limit + 360 : shape.east_limit
+  west_limit, east_limit = normalised_extent(shape)
   coords = [
-    "#{shape.west_limit} #{shape.north_limit}",
+    "#{west_limit} #{shape.north_limit}",
     "#{east_limit} #{shape.north_limit}",
     "#{east_limit} #{shape.south_limit}",
-    "#{shape.west_limit} #{shape.south_limit}",
-    "#{shape.west_limit} #{shape.north_limit}"
+    "#{west_limit} #{shape.south_limit}",
+    "#{west_limit} #{shape.north_limit}"
   ]
 
   json = {

--- a/app/views/api/v1/oni/object_meta_item.json.jb
+++ b/app/views/api/v1/oni/object_meta_item.json.jb
@@ -72,13 +72,13 @@ end
 def item_geometry_json(shape)
   id = "#geo-#{shape.west_limit},#{shape.south_limit}-#{shape.east_limit},#{shape.north_limit}"
 
-  east_limit = shape.east_limit < shape.west_limit ? shape.east_limit + 360 : shape.east_limit
+  west_limit, east_limit = normalised_extent(shape)
   coords = [
-    "#{shape.west_limit} #{shape.north_limit}",
+    "#{west_limit} #{shape.north_limit}",
     "#{east_limit} #{shape.north_limit}",
     "#{east_limit} #{shape.south_limit}",
-    "#{shape.west_limit} #{shape.south_limit}",
-    "#{shape.west_limit} #{shape.north_limit}"
+    "#{west_limit} #{shape.south_limit}",
+    "#{west_limit} #{shape.north_limit}"
   ]
 
   json = {

--- a/db/migrate/20260714000001_fix_swapped_map_extents.rb
+++ b/db/migrate/20260714000001_fix_swapped_map_extents.rb
@@ -1,0 +1,20 @@
+class FixSwappedMapExtents < ActiveRecord::Migration[8.1]
+  # A handful of records store their map extent reversed (west > east with both
+  # edges positive). A genuine antimeridian crossing always has east <= 0, so
+  # these can only be swapped entries; they render invalid WKT (longitude > 360)
+  # in every RO-Crate that references them. Rows are swapped one at a time
+  # because MySQL evaluates `SET a = b, b = a` left to right.
+  def up
+    %w[languages items collections].each do |table|
+      model = Class.new(ActiveRecord::Base) { self.table_name = table }
+      model.where('east_limit < west_limit AND east_limit > 0').find_each do |record|
+        record.update_columns(west_limit: record.east_limit, east_limit: record.west_limit)
+      end
+    end
+  end
+
+  def down
+    # Irreversible: the original rows were corrupt, and nothing distinguishes
+    # repaired rows from ones that were always correct.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_01_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_14_000001) do
   create_table "access_conditions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.string "name"

--- a/spec/models/language_spec.rb
+++ b/spec/models/language_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe Language, type: :model do
+  it 'rejects a swapped map extent (east < west with a positive east edge)' do
+    language = build(:language, west_limit: 154.64, east_limit: 140.8, north_limit: -1.59, south_limit: -12.35)
+
+    expect(language).not_to be_valid
+    expect(language.errors[:east_limit]).to be_present
+  end
+
+  it 'allows a map extent crossing the antimeridian' do
+    language = build(:language, west_limit: 170.0, east_limit: -170.0, north_limit: -1.5, south_limit: -12.25)
+
+    expect(language).to be_valid
+  end
+end

--- a/spec/requests/api/v1/oni_object_meta_geometry_spec.rb
+++ b/spec/requests/api/v1/oni_object_meta_geometry_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+# Map extents render into RO-Crates as WKT polygons. An extent crossing the
+# antimeridian is stored with east < west and a non-positive east edge and must
+# unwrap into 0..360 space; a swapped extent (east < west but east positive) is
+# bad data and must render as the box the curator meant, never as longitudes
+# beyond 360.
+describe 'Oni RO-Crate geometry', :no_catalog_upload, type: :request do
+  before { sign_in create(:user) }
+
+  def wkt_for(record, url)
+    get "/api/v1/oni/entity/#{CGI.escape(url)}/rocrate"
+
+    expect(response).to have_http_status(:ok)
+    prefix = "#geo-#{record.west_limit},#{record.south_limit}-"
+    geometry = response.parsed_body['@graph'].find { |node| node['@id'].to_s.start_with?(prefix) && node['@type'] == 'Geometry' }
+
+    expect(geometry).to be_present
+    geometry['asWKT']
+  end
+
+  # Coordinates are stored in single-precision columns, so every value below is
+  # binary-exact to keep the rendered strings stable. Extents are written with
+  # update_columns because saves now reject the swapped shape.
+  def item_wkt(west:, east:)
+    item = create(:item, north_limit: -1.5, south_limit: -12.25)
+    item.update_columns(west_limit: west, east_limit: east)
+    wkt_for(item, repository_item_url(item.collection, item))
+  end
+
+  it 'renders an ordinary extent as stored' do
+    expect(item_wkt(west: 140.25, east: 154.5))
+      .to eq('POLYGON((140.25 -1.5, 154.5 -1.5, 154.5 -12.25, 140.25 -12.25, 140.25 -1.5))')
+  end
+
+  it 'unwraps an antimeridian crossing into 0..360 space' do
+    expect(item_wkt(west: 170.5, east: -170.25))
+      .to eq('POLYGON((170.5 -1.5, 189.75 -1.5, 189.75 -12.25, 170.5 -12.25, 170.5 -1.5))')
+  end
+
+  it 'renders a swapped extent as the box the curator meant' do
+    expect(item_wkt(west: 154.5, east: 140.25))
+      .to eq('POLYGON((140.25 -1.5, 154.5 -1.5, 154.5 -12.25, 140.25 -12.25, 140.25 -1.5))')
+  end
+
+  it 'repairs swapped extents in collection crates too' do
+    collection = create(:collection, north_limit: -1.5, south_limit: -12.25)
+    collection.update_columns(west_limit: 154.5, east_limit: 140.25)
+
+    expect(wkt_for(collection, repository_collection_url(collection)))
+      .to eq('POLYGON((140.25 -1.5, 154.5 -1.5, 154.5 -12.25, 140.25 -12.25, 140.25 -1.5))')
+  end
+end


### PR DESCRIPTION
Part of wayfinder map #1163; resolves ticket #1171.

## Problem

The item/collection crate builders added 360° to `east_limit` whenever `east < west` (antimeridian handling). For extents stored swapped — `east < west` with a **positive** east edge, which can never be a genuine crossing — this emitted invalid WKT longitudes like `500.8`. Tok Pisin's swapped extent alone polluted every crate referencing it; the #1165 delta prototype hit it on 3 items + 2 collections in an 80-record sample. Left unfixed, the pdsc_admin backfill would stamp it into every regenerated crate.

## Fix (three layers)

- **Render**: a shared `normalised_extent` helper (used by both `.jb` builders) unwraps genuine crossings (`east <= 0`) into 0..360 space and swaps plainly-reversed extents back, logging a warning when it does.
- **Data**: a migration sweeps `languages`, `items` and `collections`, swapping rows where `east < west AND east > 0`. On the current prod snapshot that's 5 languages (Tok Pisin, PNG Sign Language, Mangala, Marithiel, Kawi Old Javanese — all become sensible boxes) and 1 item (AC1-421).
- **Guard**: `HasBoundaries` (now also included by `Language`) rejects the swapped shape at save time so the corruption can't quietly return.

## Verification

- New request spec covers ordinary, crossing, and swapped extents for item and collection crates; new model spec covers the validation.
- Full suite: 393 examples, 0 failures.
- Re-rendered the crates for AC1-421 and a Tok Pisin item exactly as `CatalogMetadataJob` does: every WKT longitude now in range.

Unlike #1169 this does not touch S3 keys, so it is safe to merge and deploy ahead of the pdsc_admin cutover — and it should land before the backfill runs.