### PR TITLE
feat: store paragest ingest notes on essences

### DIFF
--- a/app/graphql/types/essence_attributes.rb
+++ b/app/graphql/types/essence_attributes.rb
@@ -8,6 +8,7 @@ module Types
     argument :duration, Float, required: false
     argument :extracted_content, Types::ExtractedContentInput, required: false
     argument :fps, Integer, required: false
+    argument :ingest_notes, String, required: false
     argument :mimetype, String
     argument :samplerate, Integer, required: false
     argument :size, GraphQL::Types::BigInt

--- a/app/models/essence.rb
+++ b/app/models/essence.rb
@@ -17,6 +17,7 @@
 # **`extracted_content_type`**   | `string(255)`      |
 # **`filename`**                 | `string(255)`      |
 # **`fps`**                      | `integer`          |
+# **`ingest_notes`**             | `text(4294967295)`  |
 # **`mimetype`**                 | `string(255)`      |
 # **`samplerate`**               | `integer`          |
 # **`size`**                     | `bigint`           |

--- a/app/views/essences/show.html.haml
+++ b/app/views/essences/show.html.haml
@@ -110,6 +110,12 @@
         - preview << "… and #{segments.size - 10} more segments" if segments.size > 10
         %pre{style: 'white-space: pre-wrap; word-wrap: break-word; max-height: 300px; overflow-y: auto; padding: 8px; background: #f5f5f5; font-size: 0.9em;'}~ preview.join("\n")
 
+  - if admin_user_signed_in? && @essence.ingest_notes.present?
+    %fieldset
+      %legend Ingest Notes
+      %pre{style: 'white-space: pre-wrap; word-wrap: break-word; max-height: 300px; overflow-y: auto; padding: 8px; background: #f5f5f5; font-size: 0.9em;'}
+        = @essence.ingest_notes
+
 .twoup-2.column.span-12.last
   %fieldset
     %legend Preview

--- a/db/migrate/20260721143000_add_ingest_notes_to_essences.rb
+++ b/db/migrate/20260721143000_add_ingest_notes_to_essences.rb
@@ -1,0 +1,5 @@
+class AddIngestNotesToEssences < ActiveRecord::Migration[8.1]
+  def change
+    add_column :essences, :ingest_notes, :text, size: :long
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_21_120141) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_21_143000) do
   create_table "access_conditions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.string "name"
@@ -193,6 +193,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_21_120141) do
     t.string "extracted_content_type"
     t.string "filename"
     t.integer "fps"
+    t.text "ingest_notes", size: :long
     t.integer "item_id"
     t.string "mimetype"
     t.integer "samplerate"

--- a/nabu.graphql
+++ b/nabu.graphql
@@ -116,6 +116,7 @@ input EssenceAttributes {
   duration: Float
   extractedContent: ExtractedContentInput
   fps: Int
+  ingestNotes: String
   mimetype: String!
   samplerate: Int
   size: BigInt!

--- a/spec/controllers/essences_controller_spec.rb
+++ b/spec/controllers/essences_controller_spec.rb
@@ -8,6 +8,7 @@ describe EssencesController, type: :controller do
   let(:access_condition) { AccessCondition.new({ name: 'Open (subject to agreeing to PDSC access conditions)' }) }
   let(:item) { create(:item, collection: collection, access_condition: access_condition) }
   let(:essence) { create(:sound_essence, item: item) }
+  let(:ingest_notes) { "processS3Event: moo.wav added\nSet volume to -3dB" }
 
   let(:params) { { collection_id: collection.identifier, item_id: item.identifier, id: essence.id } }
 
@@ -91,6 +92,31 @@ describe EssencesController, type: :controller do
             expect(response.body).to include('1 segment indexed for search')
             expect(response.body).to include('transcript [00:00:01.500 - 00:00:03.0]: Spoken words')
           end
+        end
+
+        context 'when the essence has ingest notes' do
+          render_views
+
+          let(:essence) { create(:sound_essence, item: item, ingest_notes: ingest_notes) }
+
+          it 'shows the ingest notes' do
+            get :show, params: params
+            expect(response.body).to include('Ingest Notes')
+            expect(response.body).to include('Set volume to -3dB')
+          end
+        end
+      end
+
+      context 'as a non-admin when the essence has ingest notes' do
+        render_views
+
+        let(:essence) { create(:sound_essence, item: item, ingest_notes: "processS3Event: moo.wav added\nSet volume to -3dB") }
+
+        it 'does not show the ingest notes' do
+          get :show, params: params
+          expect(response.status).to eq(200)
+          expect(response.body).not_to include('Ingest Notes')
+          expect(response.body).not_to include('Set volume to -3dB')
         end
       end
 

--- a/spec/requests/api/v1/graphql_essence_ingest_notes_spec.rb
+++ b/spec/requests/api/v1/graphql_essence_ingest_notes_spec.rb
@@ -1,0 +1,102 @@
+require 'rails_helper'
+
+# Pins the persistence contract for pipeline notes the paragest ingest service submits
+# through the essence create/update mutations.
+describe 'GraphQL essence ingest notes', type: :request do
+  let(:collection) { create(:collection, private: false) }
+  let(:item) { create(:item, collection:, private: false) }
+  let(:token) { create(:m2m_admin_token) }
+  let(:base_attributes) { { mimetype: 'audio/x-wav', size: 16 } }
+  let(:essence) { create(:essence, item:, filename: 'audio.wav', ingest_notes: 'original ingest run', **base_attributes) }
+
+  let(:essence_create_mutation) do
+    <<-GRAPHQL
+      mutation CreateEssence($collectionIdentifier: String!, $itemIdentifier: String!, $filename: String!, $attributes: EssenceAttributes!) {
+        essenceCreate(input: { collectionIdentifier: $collectionIdentifier, itemIdentifier: $itemIdentifier, filename: $filename, attributes: $attributes }) {
+          essence {
+            filename
+          }
+        }
+      }
+    GRAPHQL
+  end
+
+  let(:essence_update_mutation) do
+    <<-GRAPHQL
+      mutation UpdateEssence($id: ID!, $attributes: EssenceAttributes!) {
+        essenceUpdate(input: { id: $id, attributes: $attributes }) {
+          essence {
+            filename
+          }
+        }
+      }
+    GRAPHQL
+  end
+
+  let(:notes) { "processS3Event: audio.wav added to incoming\nSet volume to -3dB\nCreated MP3 file" }
+
+  def execute_graphql(query, variables)
+    post '/graphql',
+         params: { query:, variables: }.to_json,
+         headers: { 'Authorization' => "Bearer #{token.token}", 'Content-Type' => 'application/json' }
+
+    expect(response).to have_http_status(:ok)
+
+    response.parsed_body
+  end
+
+  def create_essence(attributes)
+    execute_graphql(essence_create_mutation, {
+      collectionIdentifier: collection.identifier,
+      itemIdentifier: item.identifier,
+      filename: 'audio.wav',
+      attributes: base_attributes.merge(attributes)
+    })
+  end
+
+  def update_essence(essence, attributes)
+    execute_graphql(essence_update_mutation, {
+      id: essence.id,
+      attributes: base_attributes.merge(attributes)
+    })
+  end
+
+  it 'persists ingest notes supplied on create and records them in version history' do
+    result = create_essence(ingestNotes: notes)
+
+    expect(result['errors']).to be_nil
+
+    essence = item.essences.find_by(filename: 'audio.wav')
+    expect(essence.ingest_notes).to eq(notes)
+    expect(essence.versions.last.changeset['ingest_notes']).to eq([nil, notes])
+  end
+
+  it 'leaves ingest notes null when not supplied on create' do
+    result = create_essence({})
+
+    expect(result['errors']).to be_nil
+
+    essence = item.essences.find_by(filename: 'audio.wav')
+    expect(essence.ingest_notes).to be_nil
+  end
+
+  it 'overwrites ingest notes supplied on update' do
+    result = update_essence(essence, ingestNotes: notes)
+
+    expect(result['errors']).to be_nil
+    expect(essence.reload.ingest_notes).to eq(notes)
+  end
+
+  it 'leaves ingest notes untouched when not supplied on update' do
+    result = update_essence(essence, {})
+
+    expect(result['errors']).to be_nil
+    expect(essence.reload.ingest_notes).to eq('original ingest run')
+  end
+
+  it 'records ingest notes changes in version history on update' do
+    update_essence(essence, ingestNotes: notes)
+
+    expect(essence.versions.last.changeset['ingest_notes']).to eq(['original ingest run', notes])
+  end
+end


### PR DESCRIPTION
## Summary

- Add nullable `ingest_notes` longtext column to `essences`
- Accept an optional `ingestNotes` String on the `EssenceAttributes` GraphQL input, flowing through both `essenceCreate` and `essenceUpdate`; supplied notes overwrite, omitted notes leave the stored value untouched
- Versioned by PaperTrail (deliberately not in the ignore list) so prior ingest runs stay recoverable
- Admin-only "Ingest Notes" section on the essence show page; not exposed on the GraphQL essence output type

## Test plan

- [x] GraphQL request specs: persist on create, overwrite on update, untouched when omitted, recorded in version history (create + update)
- [x] Controller specs: admin sees the notes rendered; non-admin sees no trace
- [x] Full suite green (414 examples, 0 failures); rubocop clean

Closes #1175. Companion paragest change: paradisec-archive/paragest#39 (blocked on this deploying).